### PR TITLE
Ensure Production Toolkit CTA renders immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -1037,17 +1037,26 @@
         
         // ============================================
         // RESOURCES SECTION ANIMATIONS
+        // Ensure CTA is visible on first paint and animate without hiding
         // ============================================
-        gsap.from('.resources-inner > *', {
+        const resourcesItems = gsap.utils.toArray('.resources-inner > *');
+
+        gsap.set(resourcesItems, {
+            opacity: 1,
+            visibility: 'visible',
+            clearProps: 'opacity,visibility,transform'
+        });
+
+        gsap.from(resourcesItems, {
             scrollTrigger: {
                 trigger: '.resources-section',
                 start: 'top 80%'
             },
-            opacity: 0,
-            y: 20,
+            y: 16,
             duration: 0.8,
             stagger: 0.15,
-            ease: 'power2.out'
+            ease: 'power2.out',
+            immediateRender: false
         });
         
         // ============================================


### PR DESCRIPTION
## Summary
- keep the Production Toolkit CTA visible on initial render by clearing hidden properties
- adjust scroll animation to move the elements without forcing opacity fades

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ea256ad88327b975e3b624f66f8f)