### PR TITLE
Update community resources with social buttons

### DIFF
--- a/resources-data.js
+++ b/resources-data.js
@@ -53,6 +53,7 @@ const resources = [
             { label: 'FilmFreeway', value: 'https://filmfreeway.com/RoyalStarrFilmFestival' },
             { label: 'Instagram', value: 'https://www.instagram.com/royalstarrff/?hl=en' }
         ],
+        hideKeyInfo: true,
         features: ['Michigan Community', 'Networking', 'Events', 'Festival Hub']
     },
     {
@@ -70,6 +71,9 @@ const resources = [
         desc: 'Community for filmmakers and creators—events, meetups, and crew connection.',
         fullDesc: 'Campfire Film Cooperative is a community built around connection and craft: share work, find collaborators, and show up for events designed to spark momentum and keep projects moving.',
         url: 'https://campfirefilm.org',
+        youtubeUrl: 'https://www.youtube.com/@campfirefilmcoop',
+        facebookUrl: 'https://www.facebook.com/campfirefilm',
+        instagramUrl: 'https://www.instagram.com/campfirefilm',
         paid: false,
         features: ['Community', 'Events', 'Find Your Crew', 'Work Sharing']
     },
@@ -79,8 +83,28 @@ const resources = [
         desc: 'Monthly Detroit meetup for motion designers, animators, and CG artists.',
         fullDesc: 'Mograph Mondays Detroit is a recurring meetup for motion designers, animators, CG artists, and adjacent creatives—an easy on-ramp to post, VFX, and design collaborators.',
         url: 'https://www.mographmondays.com/det',
+        instagramUrl: 'https://www.instagram.com/mographmondaysdetroit',
+        facebookUrl: 'https://www.facebook.com/groups/mographmondays/',
         paid: false,
         features: ['Meetup', 'Motion Design', 'Animation', 'Networking']
+    },
+    {
+        name: 'Michigan Crew Calls',
+        category: 'community',
+        desc: 'Facebook group for Michigan crew opportunities and on-set needs.',
+        fullDesc: 'Michigan Crew Calls is a Facebook community built for posting and finding crew gigs, last-minute hires, and on-set opportunities across the state.',
+        url: 'https://www.facebook.com/groups/micrewcalls/',
+        paid: false,
+        features: ['Facebook Group', 'Crew Calls', 'Hiring', 'Local Production']
+    },
+    {
+        name: 'Michigan Talent Casting',
+        category: 'community',
+        desc: 'Facebook group dedicated to casting calls for Michigan talent.',
+        fullDesc: 'Michigan Talent Casting connects producers and directors with Michigan actors and performers—centralized casting posts and opportunities.',
+        url: 'https://www.facebook.com/groups/micasting/',
+        paid: false,
+        features: ['Facebook Group', 'Casting', 'Actors', 'Michigan Talent']
     },
 
     // ============================================
@@ -209,11 +233,11 @@ const resources = [
     {
         name: 'Hillier Smith',
         category: 'inspiration',
-        desc: 'Archive of title sequence design and motion graphics.',
-        fullDesc: 'Art of the Title documents the art and craft of title sequence design. Detailed breakdowns with designer interviews. Essential reference for understanding motion graphics in film and television.',
-        url: 'https://www.artofthetitle.com',
+        desc: 'High-level breakdowns on editing momentum for YouTube storytelling.',
+        fullDesc: 'Film editor Hillier Smith dissects pacing, structure, and storytelling choices for creator-led projects—practical, advanced insight for cutting modern YouTube narratives.',
+        url: 'https://www.youtube.com/@HillierSmith',
         paid: false,
-        features: ['Cinematography', 'Lighting', 'Camera Movement', 'Filmmaking']
+        features: ['Editing', 'Pacing', 'Story Structure', 'YouTube Craft']
     },
     {
         name: 'Gawx Art',
@@ -313,6 +337,15 @@ const resources = [
         url: 'https://www.youtube.com/@VivaLaDirtLeague',
         paid: false,
         features: ['Comedy', 'Sketch Writing', 'Narrative Shorts', 'High Output']
+    },
+    {
+        name: 'Joshua Bardwell',
+        category: 'inspiration',
+        desc: 'FPV drone tutorials and gear deep-dives with clear visual demos.',
+        fullDesc: 'Technical yet accessible breakdowns of FPV drone builds, tuning, and flight footage—useful reference for aerial storytelling, diagnostics, and on-set troubleshooting.',
+        url: 'https://www.youtube.com/@JoshuaBardwell',
+        paid: false,
+        features: ['FPV Drones', 'Tutorials', 'Gear Reviews', 'Practical Demos']
     },
     {
         name: 'PandaHouse',

--- a/resources.html
+++ b/resources.html
@@ -964,6 +964,15 @@
             background: rgba(228, 64, 95, 0.12);
         }
 
+        .btn--outline-facebook {
+            border-color: #316FF6;
+            color: #316FF6;
+        }
+
+        .btn--outline-facebook:hover {
+            background: rgba(49, 111, 246, 0.12);
+        }
+
         .resource-link {
             display: inline-flex;
             align-items: center;
@@ -1278,6 +1287,10 @@
             return /youtube\.com|youtu\.be/.test(url || '');
         }
 
+        function isFacebookLink(url) {
+            return /facebook\.com/.test(url || '');
+        }
+
         function getKeyInfoLink(resource, label) {
             if (!resource.keyInfo) return null;
             const matchLabel = normalizeValue(label);
@@ -1573,7 +1586,7 @@
             }
 
             let keyInfoHTML = '';
-            if (r.keyInfo) {
+            if (r.keyInfo && !r.hideKeyInfo) {
                 keyInfoHTML = '<div class="modal-section"><h3 class="section-title">Key Info</h3><div class="key-info">' +
                     r.keyInfo.map(item =>
                         '<div class="key-info-item"><span class="key-info-label">' + item.label + '</span><span>' + (item.detail || item.value) + '</span></div>'
@@ -1589,22 +1602,33 @@
             }
 
             const ctas = [];
+            const addedLinks = new Set();
             const filmFreewayLink = r.filmFreewayUrl || getKeyInfoLink(r, 'filmfreeway');
-            const instagramLink = getKeyInfoLink(r, 'instagram');
-            const isYouTube = isYouTubeLink(r.url);
+            const instagramLink = r.instagramUrl || getKeyInfoLink(r, 'instagram');
+            const facebookLink = r.facebookUrl;
+            const youtubeLink = r.youtubeUrl;
 
-            if (r.url) {
-                const label = (isInspiration || isYouTube) ? 'Watch on YouTube' : 'Website';
-                const variant = (isInspiration || isYouTube) ? 'btn--outline-youtube' : 'btn--outline-white';
-                const icon = (isInspiration || isYouTube) ? 'images/youtube-color-svgrepo-com.svg' : '';
-                ctas.push(buildCtaButton(r.url, label, variant, icon));
+            const primaryUrl = r.url;
+            if (primaryUrl) {
+                const isYouTube = isYouTubeLink(primaryUrl) || isInspiration;
+                const isFacebook = isFacebookLink(primaryUrl);
+                const label = isYouTube ? 'Watch on YouTube' : isFacebook ? 'Facebook' : 'Website';
+                const variant = isYouTube ? 'btn--outline-youtube' : isFacebook ? 'btn--outline-facebook' : 'btn--outline-white';
+                const icon = isYouTube ? 'images/youtube-color-svgrepo-com.svg' : isFacebook ? 'images/Facebook_Logo_Primary.png' : '';
+                ctas.push(buildCtaButton(primaryUrl, label, variant, icon));
+                addedLinks.add(primaryUrl);
             }
-            if (filmFreewayLink) {
-                ctas.push(buildCtaButton(filmFreewayLink, 'FilmFreeway', 'btn--outline-purple'));
+
+            function addCtaLink(link, label, variant, icon = '') {
+                if (!link || addedLinks.has(link)) return;
+                ctas.push(buildCtaButton(link, label, variant, icon));
+                addedLinks.add(link);
             }
-            if (instagramLink) {
-                ctas.push(buildCtaButton(instagramLink, 'Instagram', 'btn--outline-instagram', 'images/instagram-1-svgrepo-com.svg'));
-            }
+
+            addCtaLink(filmFreewayLink, 'FilmFreeway', 'btn--outline-purple');
+            addCtaLink(instagramLink, 'Instagram', 'btn--outline-instagram', 'images/instagram-1-svgrepo-com.svg');
+            addCtaLink(youtubeLink, 'YouTube', 'btn--outline-youtube', 'images/youtube-color-svgrepo-com.svg');
+            addCtaLink(facebookLink, 'Facebook', 'btn--outline-facebook', 'images/Facebook_Logo_Primary.png');
 
             const ctaHTML = ctas.length ? '<div class="cta-row">' + ctas.join('') + '</div>' : '';
 


### PR DESCRIPTION
## Summary
- hide the Royal Starr key info section while keeping FilmFreeway and Instagram CTAs
- add Facebook/Instagram/YouTube buttons and new community group listings
- refresh inspiration sources and CTA styling to include Facebook and YouTube icons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69574b6c229483278e6965825087e3da)