### PR TITLE
Add social buttons and reorder resource categories

### DIFF
--- a/resources-data.js
+++ b/resources-data.js
@@ -11,7 +11,10 @@ const resources = [
         category: 'collaborators',
         desc: 'Fine artist known for vibrant, nature-driven work that leans into color and mood.',
         fullDesc: 'Anthony R Brass is a fine artist whose paintings explore nature, memory, and emotion through saturated color and bold composition. His work often balances organic forms with an intuitive, expressive energy—built for close looking and slow living.',
-        url: 'https://anthonyrbrass.com',
+        url: 'https://www.anthonybrass.com',
+        instagramUrl: 'https://www.instagram.com/anthonyrbrass/',
+        youtubeUrl: 'https://www.youtube.com/channel/UChBFLCl5yzjO_vZj15_pqhw',
+        facebookUrl: 'https://www.facebook.com/anthonyRbrass/',
         features: ['Fine Art', 'Nature-Inspired', 'Documentary Subject', 'Studio Work']
     },
     {
@@ -19,7 +22,9 @@ const resources = [
         category: 'collaborators',
         desc: 'Luxury interior design studio with press features including Vanity Fair, AD, and Hour Detroit.',
         fullDesc: 'MOZ Interiors is a luxury interior design studio focused on refined spaces with strong architectural lines and elevated material choices. Their work has been featured in outlets including Vanity Fair, Architectural Digest, Hour Detroit, and The World of Interiors—design that reads clean, confident, and lived-in.',
-        url: 'https://mozinteriors.com',
+        url: 'https://www.mozinteriors.com',
+        instagramUrl: 'https://www.instagram.com/moz_interiors/',
+        facebookUrl: 'https://www.facebook.com/mozinterior',
         features: ['Interior Design', 'Press Featured', 'Commercial Partner', 'Luxury Brand']
     },
     {
@@ -27,7 +32,9 @@ const resources = [
         category: 'collaborators',
         desc: 'Composer and producer creating original scores and custom music across genres.',
         fullDesc: 'Joe Garofalo is a composer and musician crafting original scores and custom music built to support story and atmosphere. His work moves comfortably between cinematic textures, modern electronic palettes, and stripped-back instrumentation—adaptable, detailed, and mix-ready.',
-        url: null,
+        url: 'https://www.joegarofalomusic.com',
+        instagramUrl: 'https://www.instagram.com/_joegmusic_/',
+        spotifyUrl: 'https://open.spotify.com/artist/3w9fELcZkbxwfto7bZOajz',
         features: ['Original Scores', 'Music Production', 'Composer', 'Multi-Genre']
     },
     {
@@ -36,7 +43,28 @@ const resources = [
         desc: 'Detroit band featured in LaB Media live session music videos.',
         fullDesc: 'The Pandys bring raw, high-energy performances with a lived-in, no-frills feel. LaB Media captured authentic rehearsal and live-session energy with minimal production interference—momentum first, always.',
         url: null,
+        instagramUrl: 'https://www.instagram.com/thepandys/',
+        facebookUrl: 'https://www.facebook.com/thepandys/',
         features: ['Music Video', 'Live Sessions', 'Band', 'Authentic Performance']
+    },
+    {
+        name: 'PandaHouse',
+        id: 'pandahouse-collaborator',
+        category: 'collaborators',
+        desc: 'Detroit-based music project blending indie, alternative, and expressive songwriting.',
+        fullDesc: 'Atmospheric, mood-forward songwriting from Anthony Brass and collaborators. A go-to partner for emotive soundscapes, performance visuals, and music-led storytelling.',
+        url: 'https://www.pandahousedetroit.com',
+        spotifyUrl: 'https://open.spotify.com/artist/0HuGjGGYSPTGINTZpc6ziy',
+        features: ['Indie Music', 'Detroit Artist', 'Mood-Driven Sound', 'Visual Collaborator']
+    },
+    {
+        name: 'Sideways Studio',
+        category: 'collaborators',
+        desc: 'Animation and motion partner crafting expressive character-led work.',
+        fullDesc: 'Sideways Studio delivers animation and motion design with a playful, character-forward aesthetic—ideal for narrative explainers, title sequences, and stylized visual storytelling.',
+        url: 'https://sidewaysstudio.net',
+        instagramUrl: 'https://www.instagram.com/sideways_animation/',
+        features: ['Animation', 'Motion Design', 'Character Work', 'Title Design']
     },
 
     // ============================================
@@ -48,12 +76,9 @@ const resources = [
         desc: 'Michigan nonprofit building filmmaker community through mixers, events, and festival programming.',
         fullDesc: 'Royal Starr Arts Institute serves Michigan\'s creative community through networking, education, and events—anchored by Royal Starr Film Festival and recurring filmmaker mixers in Metro Detroit.',
         url: 'https://www.royalstarr.org',
+        filmFreewayUrl: 'https://filmfreeway.com/RoyalStarrFilmFestival',
+        instagramUrl: 'https://www.instagram.com/royalstarrff/?hl=en',
         paid: false,
-        keyInfo: [
-            { label: 'FilmFreeway', value: 'https://filmfreeway.com/RoyalStarrFilmFestival' },
-            { label: 'Instagram', value: 'https://www.instagram.com/royalstarrff/?hl=en' }
-        ],
-        hideKeyInfo: true,
         features: ['Michigan Community', 'Networking', 'Events', 'Festival Hub']
     },
     {
@@ -62,6 +87,21 @@ const resources = [
         desc: 'Facebook networking group for Michigan filmmakers, cast, and crew.',
         fullDesc: 'Active Facebook group for connecting Michigan filmmakers with actors, crew, and collaborators. Useful for posting gigs, staffing up, sharing resources, and finding local production support.',
         url: 'https://www.facebook.com/groups/mifilmcommunity',
+        facebookUrl: 'https://www.facebook.com/groups/mifilmcommunity',
+        additionalLinks: [
+            {
+                label: 'Michigan Crew Calls',
+                url: 'https://www.facebook.com/groups/micrewcalls/',
+                type: 'facebook',
+                description: 'Subgroup dedicated to on-set crew opportunities and urgent hires.'
+            },
+            {
+                label: 'Michigan Talent Casting',
+                url: 'https://www.facebook.com/groups/micasting/',
+                type: 'facebook',
+                description: 'Focused casting posts for Michigan-based actors and performers.'
+            }
+        ],
         paid: false,
         features: ['Facebook Group', 'Networking', 'Casting & Crew', 'Local Community']
     },
@@ -353,10 +393,8 @@ const resources = [
         desc: 'Detroit-based music project blending indie, alternative, and expressive songwriting.',
         fullDesc: 'Mood-driven songwriting with an atmospheric edge—useful inspiration for music-led visual tone and emotional pacing.',
         url: 'https://www.pandahousedetroit.com',
+        spotifyUrl: 'https://open.spotify.com/artist/0HuGjGGYSPTGINTZpc6ziy',
         paid: false,
-        keyInfo: [
-            { label: 'Spotify', value: 'https://open.spotify.com/artist/0HuGjGGYSPTGINTZpc6ziy' }
-        ],
         features: ['Indie Music', 'Detroit Artist', 'Mood-Driven Sound', 'Atmospheric Tone']
     },
 

--- a/resources.html
+++ b/resources.html
@@ -973,6 +973,39 @@
             background: rgba(49, 111, 246, 0.12);
         }
 
+        .btn--outline-spotify {
+            border-color: #1DB954;
+            color: #1DB954;
+        }
+
+        .btn--outline-spotify:hover {
+            background: rgba(29, 185, 84, 0.12);
+        }
+
+        .link-notes {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .link-note {
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            color: var(--gray-300);
+        }
+
+        .link-note-label {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 1px;
+            color: var(--gray-600);
+            text-transform: uppercase;
+        }
+
         .resource-link {
             display: inline-flex;
             align-items: center;
@@ -1129,6 +1162,8 @@
         <!-- Filter -->
         <div class="filter-row">
             <button class="filter-btn active" data-category="collaborators">Collaborators</button>
+            <button class="filter-btn" data-category="community">Community</button>
+            <button class="filter-btn" data-category="film-festivals">Film Festivals</button>
             <button class="filter-btn" data-category="music">Music</button>
             <button class="filter-btn" data-category="soundfx">Sound FX</button>
             <button class="filter-btn" data-category="ai">AI</button>
@@ -1137,8 +1172,6 @@
             <button class="filter-btn" data-category="3d">3D</button>
             <button class="filter-btn" data-category="fonts">Fonts</button>
             <button class="filter-btn" data-category="other">FreeLance</button>
-            <button class="filter-btn" data-category="community">Community</button>
-            <button class="filter-btn" data-category="film-festivals">Film Festivals</button>
             <button class="filter-btn" data-category="inspiration">Inspiration</button>
             <button class="filter-btn" data-category="all">All</button>
         </div>
@@ -1289,6 +1322,18 @@
 
         function isFacebookLink(url) {
             return /facebook\.com/.test(url || '');
+        }
+
+        function getCtaPreset(type = 'website') {
+            const presets = {
+                website: { variant: 'btn--outline-white', icon: '', label: 'Website' },
+                youtube: { variant: 'btn--outline-youtube', icon: 'images/youtube-color-svgrepo-com.svg', label: 'YouTube' },
+                instagram: { variant: 'btn--outline-instagram', icon: 'images/instagram-1-svgrepo-com.svg', label: 'Instagram' },
+                facebook: { variant: 'btn--outline-facebook', icon: 'images/Facebook_Logo_Primary.png', label: 'Facebook' },
+                spotify: { variant: 'btn--outline-spotify', icon: 'images/Spotify_Primary_Logo_RGB_Green.png', label: 'Spotify' },
+                filmfreeway: { variant: 'btn--outline-purple', icon: 'images/filmfreeway-logo-hires-white.png', label: 'FilmFreeway' }
+            };
+            return presets[type] || presets.website;
         }
 
         function getKeyInfoLink(resource, label) {
@@ -1607,28 +1652,45 @@
             const instagramLink = r.instagramUrl || getKeyInfoLink(r, 'instagram');
             const facebookLink = r.facebookUrl;
             const youtubeLink = r.youtubeUrl;
+            const spotifyLink = r.spotifyUrl;
+            const additionalLinks = r.additionalLinks || [];
 
             const primaryUrl = r.url;
             if (primaryUrl) {
                 const isYouTube = isYouTubeLink(primaryUrl) || isInspiration;
                 const isFacebook = isFacebookLink(primaryUrl);
                 const label = isYouTube ? 'Watch on YouTube' : isFacebook ? 'Facebook' : 'Website';
-                const variant = isYouTube ? 'btn--outline-youtube' : isFacebook ? 'btn--outline-facebook' : 'btn--outline-white';
-                const icon = isYouTube ? 'images/youtube-color-svgrepo-com.svg' : isFacebook ? 'images/Facebook_Logo_Primary.png' : '';
-                ctas.push(buildCtaButton(primaryUrl, label, variant, icon));
+                const primaryType = isYouTube ? 'youtube' : isFacebook ? 'facebook' : 'website';
+                const preset = getCtaPreset(primaryType);
+                ctas.push(buildCtaButton(primaryUrl, label || preset.label, preset.variant, preset.icon));
                 addedLinks.add(primaryUrl);
             }
 
-            function addCtaLink(link, label, variant, icon = '') {
+            function addCtaLink(link, label, type = 'website') {
                 if (!link || addedLinks.has(link)) return;
-                ctas.push(buildCtaButton(link, label, variant, icon));
+                const preset = getCtaPreset(type);
+                const finalLabel = label || preset.label;
+                ctas.push(buildCtaButton(link, finalLabel, preset.variant, preset.icon));
                 addedLinks.add(link);
             }
 
-            addCtaLink(filmFreewayLink, 'FilmFreeway', 'btn--outline-purple');
-            addCtaLink(instagramLink, 'Instagram', 'btn--outline-instagram', 'images/instagram-1-svgrepo-com.svg');
-            addCtaLink(youtubeLink, 'YouTube', 'btn--outline-youtube', 'images/youtube-color-svgrepo-com.svg');
-            addCtaLink(facebookLink, 'Facebook', 'btn--outline-facebook', 'images/Facebook_Logo_Primary.png');
+            addCtaLink(filmFreewayLink, 'FilmFreeway', 'filmfreeway');
+            addCtaLink(instagramLink, 'Instagram', 'instagram');
+            addCtaLink(youtubeLink, 'YouTube', 'youtube');
+            addCtaLink(facebookLink, 'Facebook', 'facebook');
+            addCtaLink(spotifyLink, 'Spotify', 'spotify');
+
+            const linkNotes = [];
+            additionalLinks.forEach(link => {
+                if (!link || !link.url) return;
+                const preset = getCtaPreset(link.type);
+                addCtaLink(link.url, link.label, link.type);
+                if (link.description) {
+                    linkNotes.push('<div class="link-note"><span class="link-note-label">' + (link.label || preset.label) + '</span><span class="link-note-desc">' + link.description + '</span></div>');
+                }
+            });
+
+            const relatedLinksHTML = linkNotes.length ? '<div class="modal-section"><h3 class="section-title">More Links</h3><div class="link-notes">' + linkNotes.join('') + '</div></div>' : '';
 
             const ctaHTML = ctas.length ? '<div class="cta-row">' + ctas.join('') + '</div>' : '';
 
@@ -1637,6 +1699,7 @@
                 keyInfoHTML +
                 pricingHTML +
                 featuresHTML +
+                relatedLinksHTML +
                 ctaHTML;
             
             modal.classList.remove('closing');


### PR DESCRIPTION
## Summary
- add collaborator and community social links with icon-powered CTAs for bios and related pages
- expand resources modal to support Spotify, FilmFreeway, and additional link notes while keeping inspiration YouTube styling
- reorder resource filters so Community and Film Festivals sit next to Collaborators

## Testing
- not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69575256bae883279fda5b46e53ae420)