### PR TITLE
Remove accent line glow and add documentation

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1,0 +1,22 @@
+# LaB Media — Running Changelog (Rolling)
+
+Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
+
+## YYYY-MM-DD
+- Change:
+- Files touched:
+- Notes:
+- Quick test checklist:
+
+---
+Example template:
+
+## 2026-01-03
+- Change: Removed glow from accent-line animations so they match the crisp “Scroll” line behavior.
+- Files touched: index.html, plan-your-project.html
+- Notes: Accent line pseudo-elements now explicitly disable box-shadow/filter.
+- Quick test checklist:
+  - Confirm hero lines animate with no halo/glow
+  - Confirm poster lines animate with no halo/glow
+  - Test on mobile + desktop
+  - Check prefers-reduced-motion still behaves

--- a/LAB_STYLE_GUIDE.md
+++ b/LAB_STYLE_GUIDE.md
@@ -1,0 +1,73 @@
+# LaB Media — Style Guide (Prototype / Retrofuturist Minimal)
+
+This site is pure HTML/CSS/JS with GSAP. No build step by default. Keep it fast, crisp, and “high-tech but tasteful.”
+
+## North Star
+- Minimal UI, maximal intention.
+- “Prototype / retrofuturism” cues: corner brackets, scan lines, accent lines, status-y UI hints.
+- Avoid “busy cyberpunk.” No neon soup, no visual spam.
+
+## Typography
+- Headings: Space Mono (display/tech vibe)
+- Body/UI: Inter
+
+Rules:
+- Prefer fewer sizes; let spacing + weight do the work.
+- Avoid long all-caps paragraphs.
+- Keep line-length readable (roughly 55–85 chars when possible).
+
+## Color + Crisp Lines (No Glow on Accent Lines)
+- Base palette: grayscale/dark
+- Accents: cyan/blue/orange sparingly
+
+Accent line rules (important):
+- Accent lines must be crisp and **non-glowy**
+- No `box-shadow` halos on accent lines
+- No “neon blur” look
+- Use opacity + position animation for the “breathing” effect
+- Solid white is preferred; avoid gradients for lines unless explicitly requested
+
+Where glow *is* allowed (optional):
+- Small, controlled emphasis on buttons/cards (hover/active), never everywhere at once
+- If used: keep it subtle and localized (no foggy UI)
+
+## Buttons + Links
+- Buttons should feel “instrument panel”:
+  - clear affordance (hover, active)
+  - high contrast
+  - consistent padding and radius
+- Links in detail/bio views are buttons when they matter (Website / FilmFreeway / Instagram / YouTube).
+- External links open in a new tab where appropriate.
+
+## Motion + Interaction
+- Default: micro-interactions, not constant movement.
+- Must respect `prefers-reduced-motion`.
+- Scroll reveals: smooth, not jittery.
+
+Accent line spec (the “Scroll line” baseline):
+- Bright, crisp, “breathing” ease-in/out
+- Higher peak opacity than other lines
+- Minimal blur; ideally none
+- Animation should be periodic and calm, not frantic
+- **No glow on the lines**
+
+## Accessibility (Non-negotiable)
+- Keyboard usable:
+  - Focus states visible and consistent
+  - Modals have focus trap, ESC close, backdrop close
+  - Return focus to trigger on close
+- ARIA only when it helps; don’t add junk ARIA.
+- Color contrast: ensure readable text on dark backgrounds.
+
+## Performance Guardrails
+- Don’t re-render huge DOM trees unnecessarily.
+- Prefer event delegation where reasonable.
+- Lazy-load heavy embeds (YouTube) and heavy data (resources) where possible.
+- Keep third-party scripts lazy-loaded and isolated.
+
+## “No framework unless justified”
+Vanilla wins unless:
+- You can prove maintenance/performance/feature velocity improvements
+- AND you can ship it without breaking the vibe
+
+If proposing React/Vue/etc, provide a clear migration plan and why it’s worth it.

--- a/RESOURCES_SCHEMA.md
+++ b/RESOURCES_SCHEMA.md
@@ -1,0 +1,77 @@
+# LaB Media — Resources Data Contract
+
+Single source of truth for resources displayed on `resources.html`. This prevents “tiles showing bio-only info” regressions.
+
+## Resource Object (canonical)
+Required:
+- `name` (string) — display title
+- `category` (string) — canonical category key (must match UI filters)
+- `desc` (string) — short tile description (1–2 lines)
+- `fullDesc` (string) — bio/detail description (multi-sentence allowed)
+
+Common optional:
+- `url` (string) — primary website link
+- `labPick` (boolean) — show “LaB Pick” badge
+- `paid` (boolean) — paid vs free badge logic (only where applicable)
+- `features` (string[]) — bullet traits shown in bio
+- `tags` (string[]) — secondary tags for filtering/search (if supported)
+
+Social/media optional:
+- `instagramUrl` (string)
+- `youtubeUrl` (string) — for channels or specific videos
+- `vimeoUrl` (string)
+- `tiktokUrl` (string)
+
+Film festival optional:
+- `filmFreewayUrl` (string) — FilmFreeway link
+
+## Rendering Rules: Tile vs Bio (Critical)
+Tile/grid card MUST ONLY show:
+- `name`
+- `desc`
+- small badges (category, labPick, free/paid if relevant)
+- minimal tags if already part of the current design
+
+Tile/grid card MUST NOT show:
+- FilmFreeway URLs
+- long descriptions (`fullDesc`)
+- pricing tables / big link lists
+- social icons cluster
+
+Bio/detail view may show:
+- `fullDesc`
+- features
+- primary links:
+  - Website button if `url`
+  - FilmFreeway button if `filmFreewayUrl`
+  - Social icon buttons if corresponding URLs exist
+
+## Category Rules
+- Categories must be exclusive when intended.
+  - Example: Film festivals should not leak into Community.
+- If you support tags, tags can overlap, but the primary category must remain correct.
+
+## Pricing Rules
+Pricing is optional and only valid for categories that sell something or have tiers.
+- Inspiration (YouTube channels) should NOT show pricing.
+- If pricing exists, it belongs in bio view only (unless explicitly designed otherwise).
+
+## “Lab Pick” Rules
+- `labPick: true` shows a badge on tile and bio.
+- Do not overload “Lab Pick” into multiple different visuals.
+
+## Data Hygiene
+- No duplicate resources by name.
+- URLs must include protocol (`https://`).
+- Keep descriptions human and clean (no keyword spam).
+- If info is unknown, omit the field; don’t invent.
+
+## Events extraction hooks (future-proofing)
+If a resource has known event dates:
+- Prefer adding event info to a separate `events-data.js`
+- Or add optional fields (only if we decide to support it consistently):
+  - `eventDate` (YYYY-MM-DD)
+  - `eventEndDate` (YYYY-MM-DD)
+  - `deadlineDate` (YYYY-MM-DD)
+
+But do not sprinkle inconsistent date fields across random items without a plan.

--- a/index.html
+++ b/index.html
@@ -166,6 +166,8 @@
             content: '';
             position: absolute;
             background: linear-gradient(90deg, transparent, var(--white), transparent);
+            box-shadow: none;
+            filter: none;
         }
 
         .hero-line.vertical {

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -115,6 +115,8 @@
             content: '';
             position: absolute;
             background: linear-gradient(90deg, transparent, var(--white), transparent);
+            box-shadow: none;
+            filter: none;
         }
 
         .poster-line.vertical {


### PR DESCRIPTION
## Summary
- remove glow effects from hero and poster accent lines to keep visuals crisp
- add project style guide, resources schema, and running changelog documentation at repo root

## Testing
- not run (static content changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959d554923883279c16a653e1681451)