### PR TITLE
Add quick filters and suggest event modal

### DIFF
--- a/events.html
+++ b/events.html
@@ -1,12 +1,535 @@
-Placeholder for Events Page
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Events | LaB Media</title>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
 
+    <!-- Prototype Design System -->
+    <link rel="stylesheet" href="prototype-theme.css">
 
-Calendar
+    <style>
+        :root {
+            --black: #000000;
+            --white: #FFFFFF;
+            --gray-200: #C5C5C5;
+            --gray-300: #B0B0B0;
+            --gray-400: #888888;
+            --gray-600: #555555;
+            --gray-800: #1A1A1A;
+            --gray-900: #0D0D0D;
+            --lab-orange: #F97316;
+        }
 
+        * { box-sizing: border-box; }
 
-Blog section or post stye section for recent events info or posts and things, 
+        body {
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: var(--black);
+            color: var(--gray-300);
+            margin: 0;
+            min-height: 100vh;
+        }
 
+        a { color: inherit; text-decoration: none; }
 
+        .page-shell {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1.5rem 3rem;
+        }
 
-nice links for some of the community resources like camfire and royal star meetups
+        header.page-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
+        }
+
+        .brand {
+            font-family: 'Space Mono', monospace;
+            color: var(--white);
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            font-size: 0.95rem;
+        }
+
+        nav ul {
+            list-style: none;
+            display: flex;
+            gap: 1rem;
+            padding: 0;
+            margin: 0;
+        }
+
+        nav a {
+            font-family: 'Space Mono', monospace;
+            color: var(--gray-300);
+            padding: 0.35rem 0.6rem;
+            border: 1px solid transparent;
+            transition: border-color 0.2s ease, color 0.2s ease;
+        }
+
+        nav a:hover {
+            color: var(--white);
+            border-color: var(--gray-800);
+        }
+
+        .hero {
+            margin-top: 1rem;
+            padding: 1rem 0 0.5rem;
+        }
+
+        .hero h1 {
+            font-family: 'Space Mono', monospace;
+            color: var(--white);
+            font-size: 2.3rem;
+            margin: 0 0 0.25rem;
+        }
+
+        .hero p {
+            margin: 0;
+            color: var(--gray-400);
+            max-width: 720px;
+            line-height: 1.6;
+        }
+
+        .view-toggle {
+            margin-top: 1.25rem;
+            display: inline-flex;
+            gap: 0.5rem;
+        }
+
+        .view-btn {
+            border: 1px solid rgba(255,255,255,0.18);
+            background: rgba(255,255,255,0.03);
+            color: var(--gray-300);
+            padding: 0.5rem 0.85rem;
+            cursor: pointer;
+            font-family: 'Space Mono', monospace;
+            transition: transform 0.1s ease, border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+        }
+
+        .view-btn:hover { transform: translateY(-1px); color: var(--white); }
+        .view-btn.active {
+            border-color: rgba(255,255,255,0.35);
+            background: rgba(255,255,255,0.06);
+            color: var(--white);
+        }
+
+        /* Suggest Event */
+        .hero-actions {
+            margin-top: 1rem;
+            display: flex;
+            justify-content: flex-start;
+        }
+        .suggest-btn {
+            border: 1px solid rgba(255,255,255,0.18);
+            background: rgba(255,255,255,0.04);
+            color: var(--white);
+            padding: 0.75rem 1rem;
+            cursor: pointer;
+            transition: transform 0.12s ease, background 0.2s ease, border-color 0.2s ease;
+            font-family: 'Space Mono', monospace;
+        }
+        .suggest-btn:hover { transform: translateY(-1px); background: rgba(255,255,255,0.06); }
+        .suggest-btn:active { transform: translateY(0); }
+
+        /* Layout */
+        .view-section {
+            margin-top: 2rem;
+        }
+
+        .calendar-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 1rem;
+        }
+
+        .event-card {
+            border: 1px solid rgba(255,255,255,0.12);
+            background: rgba(255,255,255,0.02);
+            padding: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .event-date {
+            font-family: 'Space Mono', monospace;
+            color: var(--gray-200);
+            font-size: 0.85rem;
+            letter-spacing: 1px;
+        }
+
+        .event-name {
+            color: var(--white);
+            font-size: 1.05rem;
+            margin: 0;
+        }
+
+        .event-meta {
+            color: var(--gray-400);
+            font-size: 0.9rem;
+        }
+
+        .event-type {
+            display: inline-block;
+            border: 1px solid rgba(255,255,255,0.12);
+            padding: 0.15rem 0.4rem;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.75rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: var(--gray-200);
+        }
+
+        .list-view {
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .list-row {
+            display: grid;
+            grid-template-columns: 1.5fr 1fr 1fr 0.8fr;
+            align-items: center;
+            padding: 0.75rem 1rem;
+            border: 1px solid rgba(255,255,255,0.1);
+            background: rgba(255,255,255,0.02);
+        }
+
+        .list-row h4 { margin: 0; color: var(--white); }
+        .list-row span { color: var(--gray-400); font-size: 0.95rem; }
+
+        .list-header {
+            font-family: 'Space Mono', monospace;
+            color: var(--gray-400);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            border-color: rgba(255,255,255,0.18);
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.25rem 0.5rem;
+            border: 1px solid rgba(255,255,255,0.14);
+            font-family: 'Space Mono', monospace;
+            font-size: 0.75rem;
+            color: var(--gray-200);
+        }
+
+        /* Suggest modal */
+        .suggest-backdrop {
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.68);
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.25rem;
+            z-index: 1400;
+            transition: opacity 0.2s ease, visibility 0.2s ease;
+        }
+        .suggest-backdrop.is-open {
+            opacity: 1;
+            visibility: visible;
+            pointer-events: auto;
+        }
+        .suggest-modal {
+            width: min(720px, 100%);
+            max-height: 80vh;
+            overflow: auto;
+            background: var(--black);
+            border: 1px solid rgba(255,255,255,0.14);
+            padding: 1rem;
+        }
+        .suggest-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+        .suggest-title { color: var(--white); font-family: 'Space Mono', monospace; }
+        .suggest-close {
+            width: 40px;
+            height: 40px;
+            border: 1px solid rgba(255,255,255,0.14);
+            background: rgba(255,255,255,0.04);
+            color: var(--white);
+            cursor: pointer;
+        }
+        .suggest-form {
+            display: grid;
+            gap: 0.75rem;
+        }
+        .suggest-form label {
+            font-family: 'Space Mono', monospace;
+            color: var(--gray-300);
+            font-size: 0.85rem;
+            display: grid;
+            gap: 0.35rem;
+        }
+        .suggest-form input,
+        .suggest-form select,
+        .suggest-form textarea {
+            width: 100%;
+            padding: 0.75rem;
+            border: 1px solid rgba(255,255,255,0.14);
+            background: rgba(255,255,255,0.03);
+            color: var(--white);
+            font-family: 'Inter', sans-serif;
+        }
+        .suggest-form textarea { min-height: 110px; resize: vertical; }
+        .suggest-submit {
+            border: 1px solid rgba(255,255,255,0.18);
+            background: rgba(255,255,255,0.06);
+            color: var(--white);
+            padding: 0.75rem 1rem;
+            cursor: pointer;
+            font-family: 'Space Mono', monospace;
+        }
+        @media (max-width: 768px) {
+            .list-row { grid-template-columns: 1fr; gap: 0.35rem; }
+            .list-header { display: none; }
+            .suggest-modal { max-height: 90vh; }
+        }
+    </style>
+</head>
+<body>
+    <div class="page-shell">
+        <header class="page-header">
+            <div class="brand">LaB Media</div>
+            <nav aria-label="Main Navigation">
+                <ul>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="resources.html">Resources</a></li>
+                    <li><a href="events.html">Events</a></li>
+                    <li><a href="plan-your-project.html">Project</a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <section class="hero">
+            <h1>Events</h1>
+            <p>Deadlines, screenings, meetups, and festivals that keep the LaB community connected. Toggle views to browse.</p>
+
+            <div class="view-toggle">
+                <button class="view-btn active" data-view="calendar">📅 Calendar</button>
+                <button class="view-btn" data-view="list">📋 List</button>
+            </div>
+
+            <div class="hero-actions">
+                <button class="suggest-btn proto-text-mono" id="suggestEventBtn" type="button">+ Suggest Event</button>
+            </div>
+        </section>
+
+        <section class="view-section" id="calendarSection">
+            <div class="calendar-grid" id="calendarGrid" aria-live="polite"></div>
+        </section>
+
+        <section class="view-section" id="listSection" hidden>
+            <div class="list-view">
+                <div class="list-row list-header">
+                    <span>Event</span>
+                    <span>Date</span>
+                    <span>Location</span>
+                    <span>Type</span>
+                </div>
+                <div id="listContainer"></div>
+            </div>
+        </section>
+    </div>
+
+    <!-- Suggest Event Modal -->
+    <div class="suggest-backdrop" id="suggestBackdrop" aria-hidden="true">
+        <div class="suggest-modal" id="suggestDialog" role="dialog" aria-modal="true" aria-labelledby="suggestTitle" tabindex="-1">
+            <div class="suggest-header">
+                <div>
+                    <div class="proto-text-mono" style="opacity:0.7;">Community Contribution</div>
+                    <h3 class="suggest-title" id="suggestTitle">Suggest an Event</h3>
+                </div>
+                <button class="suggest-close" id="suggestClose" type="button" aria-label="Close">×</button>
+            </div>
+
+            <form class="suggest-form" action="https://formspree.io/f/mkgvggge" method="POST">
+                <input type="hidden" name="source" value="events-page">
+                <label>
+                    Event name
+                    <input name="event_name" required>
+                </label>
+
+                <label>
+                    Type
+                    <select name="event_type" required>
+                        <option value="festival">Festival</option>
+                        <option value="meetup">Meetup</option>
+                        <option value="deadline">Deadline</option>
+                        <option value="screening">Screening</option>
+                        <option value="workshop">Workshop</option>
+                        <option value="other">Other</option>
+                    </select>
+                </label>
+
+                <label>
+                    Start date
+                    <input type="date" name="start_date" required>
+                </label>
+
+                <label>
+                    End date (optional)
+                    <input type="date" name="end_date">
+                </label>
+
+                <label>
+                    Location (city/state)
+                    <input name="location">
+                </label>
+
+                <label>
+                    Link (optional)
+                    <input name="url" placeholder="https://">
+                </label>
+
+                <label>
+                    Notes (optional)
+                    <textarea name="notes" placeholder="Any details, deadlines, FilmFreeway link, etc."></textarea>
+                </label>
+
+                <button class="suggest-submit" type="submit">Send Suggestion</button>
+            </form>
+        </div>
+    </div>
+
+    <script>
+        const eventsData = [
+            { name: 'LaB Monthly Meetup', start: '2024-08-10', end: '', location: 'Los Angeles, CA', type: 'meetup', url: '' },
+            { name: 'Festival Submission Deadline', start: '2024-09-01', end: '', location: 'Online', type: 'deadline', url: '' },
+            { name: 'Indie Screening Night', start: '2024-09-15', end: '', location: 'Austin, TX', type: 'screening', url: '' },
+            { name: 'Workshop: Color Grading', start: '2024-10-05', end: '2024-10-06', location: 'Brooklyn, NY', type: 'workshop', url: '' }
+        ];
+
+        const viewButtons = document.querySelectorAll('.view-btn');
+        const calendarSection = document.getElementById('calendarSection');
+        const listSection = document.getElementById('listSection');
+        const calendarGrid = document.getElementById('calendarGrid');
+        const listContainer = document.getElementById('listContainer');
+
+        function formatDate(dateStr) {
+            if (!dateStr) return '';
+            const date = new Date(dateStr + 'T00:00:00');
+            return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+
+        function renderCalendar() {
+            const sorted = [...eventsData].sort((a, b) => new Date(a.start) - new Date(b.start));
+            calendarGrid.innerHTML = sorted.map(ev => `
+                <article class="event-card">
+                    <div class="event-date">${formatDate(ev.start)}${ev.end ? ' – ' + formatDate(ev.end) : ''}</div>
+                    <h3 class="event-name">${ev.name}</h3>
+                    <div class="event-meta">${ev.location || 'TBD'}</div>
+                    <span class="event-type">${ev.type}</span>
+                </article>
+            `).join('');
+        }
+
+        function renderList() {
+            const sorted = [...eventsData].sort((a, b) => new Date(a.start) - new Date(b.start));
+            listContainer.innerHTML = sorted.map(ev => `
+                <div class="list-row">
+                    <h4>${ev.name}</h4>
+                    <span>${formatDate(ev.start)}${ev.end ? ' – ' + formatDate(ev.end) : ''}</span>
+                    <span>${ev.location || 'TBD'}</span>
+                    <span class="tag">${ev.type}</span>
+                </div>
+            `).join('');
+        }
+
+        function setView(view) {
+            viewButtons.forEach(btn => btn.classList.toggle('active', btn.dataset.view === view));
+            if (view === 'list') {
+                listSection.hidden = false;
+                calendarSection.hidden = true;
+            } else {
+                listSection.hidden = true;
+                calendarSection.hidden = false;
+            }
+        }
+
+        viewButtons.forEach(btn => {
+            btn.addEventListener('click', () => setView(btn.dataset.view));
+        });
+
+        renderCalendar();
+        renderList();
+
+        // ============================================
+        // SUGGEST EVENT MODAL (accessible, lightweight)
+        // ============================================
+        const suggestEventBtn = document.getElementById('suggestEventBtn');
+        const suggestBackdrop = document.getElementById('suggestBackdrop');
+        const suggestDialog = document.getElementById('suggestDialog');
+        const suggestClose = document.getElementById('suggestClose');
+
+        const focusableSel = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+        let lastFocusEl = null;
+
+        function openSuggestModal() {
+            if (!suggestBackdrop) return;
+            lastFocusEl = document.activeElement;
+            suggestBackdrop.classList.add('is-open');
+            suggestBackdrop.setAttribute('aria-hidden', 'false');
+            const first = suggestDialog.querySelector('input, select, textarea, button');
+            (first || suggestDialog).focus();
+        }
+
+        function closeSuggestModal() {
+            if (!suggestBackdrop) return;
+            suggestBackdrop.classList.remove('is-open');
+            suggestBackdrop.setAttribute('aria-hidden', 'true');
+            if (lastFocusEl && lastFocusEl.focus) lastFocusEl.focus();
+        }
+
+        function trapFocus(e) {
+            if (!suggestBackdrop.classList.contains('is-open')) return;
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                closeSuggestModal();
+                return;
+            }
+            if (e.key !== 'Tab') return;
+
+            const focusables = Array.from(suggestDialog.querySelectorAll(focusableSel)).filter(el => el.offsetParent !== null);
+            if (!focusables.length) return;
+
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        }
+
+        if (suggestEventBtn) suggestEventBtn.addEventListener('click', openSuggestModal);
+        if (suggestClose) suggestClose.addEventListener('click', closeSuggestModal);
+        if (suggestBackdrop) {
+            suggestBackdrop.addEventListener('click', (e) => {
+                if (e.target === suggestBackdrop) closeSuggestModal();
+            });
+        }
+        document.addEventListener('keydown', trapFocus);
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1393,6 +1393,7 @@
             <li><a href="portfolio.html">Work</a></li>
             <li><a href="plan-your-project.html">Project</a></li>
             <li><a href="resources.html">Resources</a></li>
+            <li><a href="events.html">Events</a></li>
             <li><a href="#contact">Contact</a></li>
             <li><button type="button" id="voiceAgentButton">Voice Agent</button></li>
         </ul>

--- a/resources.html
+++ b/resources.html
@@ -764,7 +764,67 @@
             from { opacity: 0; transform: translateY(10px); }
             to { opacity: 1; transform: translateY(0); }
         }
-        
+
+        /* ============================================
+           SKELETON LOADING (cards)
+        ============================================ */
+        .resource-card.is-skeleton {
+            cursor: default;
+            pointer-events: none;
+            opacity: 1;
+            animation: none;
+        }
+        .resource-card.is-skeleton .card-index,
+        .resource-card.is-skeleton .card-name,
+        .resource-card.is-skeleton .card-description,
+        .resource-card.is-skeleton .card-badges,
+        .resource-card.is-skeleton .card-arrow {
+            visibility: hidden;
+        }
+        .resource-card.is-skeleton::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(90deg,
+                rgba(255,255,255,0.04),
+                rgba(255,255,255,0.08),
+                rgba(255,255,255,0.04)
+            );
+            transform: translateX(-60%);
+            animation: skeletonShimmer 1.2s ease-in-out infinite;
+            opacity: 0.9;
+        }
+        @keyframes skeletonShimmer {
+            0% { transform: translateX(-60%); }
+            100% { transform: translateX(60%); }
+        }
+
+        /* ============================================
+           QUICK FILTERS (multi-toggle)
+        ============================================ */
+        .quickfilter-row {
+            margin-top: 1rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+        .quickfilter-btn {
+            border: 1px solid rgba(255,255,255,0.14);
+            background: rgba(255,255,255,0.03);
+            color: var(--gray-300);
+            padding: 0.5rem 0.75rem;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: transform 0.12s ease, border-color 0.2s ease, background 0.2s ease;
+        }
+        .quickfilter-btn:hover { transform: translateY(-1px); }
+        .quickfilter-btn.is-active {
+            border-color: rgba(255,255,255,0.35);
+            background: rgba(255,255,255,0.06);
+            color: var(--white);
+        }
+
         .resource-card::before {
             content: '';
             position: absolute;
@@ -1559,6 +1619,13 @@
             <button class="filter-btn" data-category="all">All</button>
         </div>
 
+        <!-- Quick Filters -->
+        <div class="quickfilter-row" id="quickFilterBar" aria-label="Quick filters">
+            <button class="quickfilter-btn" type="button" data-qf="labPick">LaB Picks</button>
+            <button class="quickfilter-btn" type="button" data-qf="free">Free</button>
+            <button class="quickfilter-btn" type="button" data-qf="paid">Paid</button>
+        </div>
+
         <div class="subfilter-row" id="musicTierBar" aria-live="polite" hidden>
             <span class="subfilter-label">Music view:</span>
             <div class="subfilter-buttons">
@@ -1672,6 +1739,14 @@
         const aiTypeButtons = aiTypeBar.querySelectorAll('.subfilter-btn');
         const droneTypeBar = document.getElementById('droneTypeBar');
         const droneTypeButtons = droneTypeBar.querySelectorAll('.subfilter-btn');
+
+        const quickFilterBar = document.getElementById('quickFilterBar');
+        const quickFilterButtons = quickFilterBar ? quickFilterBar.querySelectorAll('.quickfilter-btn') : [];
+        const quickFilters = {
+            labPick: false,
+            free: false,
+            paid: false
+        };
 
         let currentCategory = 'film-festivals';
         let searchQuery = '';
@@ -1823,6 +1898,22 @@
                 });
             }
 
+            // Quick filters (multi-toggle)
+            const wantsLabPick = quickFilters.labPick;
+            const wantsFree = quickFilters.free;
+            const wantsPaid = quickFilters.paid;
+
+            if (wantsLabPick) {
+                filtered = filtered.filter(r => r.labPick === true);
+            }
+
+            // Free/Paid toggles work across categories when r.paid is present.
+            // If both are off, allow all. If one is on, filter accordingly.
+            if (wantsFree !== wantsPaid) {
+                if (wantsFree) filtered = filtered.filter(r => r.paid === false);
+                if (wantsPaid) filtered = filtered.filter(r => r.paid === true);
+            }
+
             // Dedupe before sorting
             filtered = dedupeResources(filtered);
 
@@ -1901,7 +1992,24 @@
         // ============================================
         // RENDER LOGIC
         // ============================================
-        
+
+        function buildSkeletonGrid(count = 8) {
+            const skeletonCount = Math.max(6, Math.min(count, 12));
+            let html = '';
+            for (let i = 0; i < skeletonCount; i++) {
+                html += `
+                    <div class="resource-card is-skeleton">
+                        <span class="card-index">${String(i + 1).padStart(3, '0')}</span>
+                        <h3 class="card-name">Loading</h3>
+                        <div class="card-badges"></div>
+                        <p class="card-description">Loading</p>
+                        <span class="card-arrow">→</span>
+                    </div>
+                `;
+            }
+            grid.innerHTML = html;
+        }
+
         function renderResources(animate = false) {
             if (currentCategory === 'music') {
                 musicTierBar.removeAttribute('hidden');
@@ -1929,10 +2037,16 @@
             
             // Set data-count attribute for CSS adaptive grid
             grid.setAttribute('data-count', Math.min(count, 12));
-            
+
             if (animate) {
-                grid.style.opacity = '0';
-                grid.style.transform = 'translateY(10px)';
+                // Show skeletons immediately for a modern loading feel
+                grid.style.transition = 'none';
+                buildSkeletonGrid();
+                grid.style.opacity = '1';
+                grid.style.transform = 'translateY(0)';
+                // Force reflow so the next transition applies cleanly
+                void grid.offsetHeight;
+
                 setTimeout(() => {
                     buildGrid(filtered);
                     grid.style.transition = 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)';
@@ -2328,6 +2442,28 @@
                 setCategory(btn.dataset.category);
                 renderResources(true);
             });
+        });
+
+        // Quick filters (multi-toggle)
+        if (quickFilterButtons.length) {
+            quickFilterButtons.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const key = btn.dataset.qf;
+                    if (!key || !(key in quickFilters)) return;
+                    quickFilters[key] = !quickFilters[key];
+                    btn.classList.toggle('is-active', quickFilters[key]);
+                    renderResources(true);
+                });
+            });
+        }
+
+        // Keyboard shortcut: / focuses search (like a real app)
+        document.addEventListener('keydown', (e) => {
+            if (e.key !== '/') return;
+            const tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : '';
+            if (tag === 'input' || tag === 'textarea' || e.target.isContentEditable) return;
+            e.preventDefault();
+            searchInput.focus();
         });
 
         musicTierButtons.forEach(btn => {


### PR DESCRIPTION
## Summary
- add skeleton loading state and quick filter toggles to resources
- build the events page with view toggles and an accessible suggest-event modal
- link the new events page from the main navigation

## Testing
- not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959d7aced4083279bdf202648a4659b)