### PR TITLE
Add verification badges and refresh event listings

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -123,3 +123,12 @@ Quick test checklist:
 - Toggle Inspiration/Editing/Filming/Art/Music/References/Comedy/All → results stay populated
 - Select Drones → Drone subfilter row shows; Part 107/Channels/Stores/All filter items accordingly
 - Console free of errors (favicon only)
+2026-01-04 | 4:58PM EST
+———————————————————————
+Change: Refresh events data, add verification badges for unverified listings, and display Film Fest labeling in type tags and modal previews.
+Files touched: events.html, events-data.js, CHANGELOG_RUNNING.md
+Notes: Added optional verification badge logic that links to event URLs when present while keeping verified events unchanged.
+Quick test checklist:
+- Load events page in list view: unverified Royal Starr mixers show orange badge beside type label; verified events display normally.
+- Open the Royal Starr mixer modal: badge appears near the type/status chips and links to the event site; Film Fest label shows for festival types.
+- Confirm no console errors on page load after hard refresh.

--- a/events-data.js
+++ b/events-data.js
@@ -4,85 +4,124 @@
 // ============================================
 
 const eventsData = [
+  // ============================================
+  // UPCOMING (Verified / Active listings)
+  // ============================================
+
   {
-    id: 'royal-starr-mixer-2026-01',
-    title: 'Royal Starr Filmmaker Community Mixer',
+    id: 'royal-starr-new-year-mixer-2026-01-13',
+    title: 'Royal Starr Filmmaker New Year Mixer',
     type: 'meetup',
     startDate: '2026-01-13',
-    startTime: '18:00',
-    endTime: '21:00',
-    location: 'Royal Oak, MI',
-    venue: 'Royal Starr Arts Institute',
+    // Facebook/event listings can change—verify before posting hard details
+    startTime: '19:00',
+    endTime: '22:00',
+    location: 'Metro Detroit, MI',
+    venue: 'TBD (check RSVP / listing)',
     url: 'https://www.royalstarr.org',
-    description: 'Monthly filmmaker community mixer (2nd Tuesday). Upcoming date derived from their recurring cadence — confirm ahead.'
+    description: 'Royal Starr New Year mixer (listed for Jan 13). Confirm exact venue/time via RSVP/listing before sharing widely.',
+    verification: 'partial (listing found; confirm final details)'
   },
   {
-    id: 'royal-starr-mixer-2026-02',
+    id: 'royal-starr-mixer-2026-02-10',
     title: 'Royal Starr Filmmaker Community Mixer',
     type: 'meetup',
     startDate: '2026-02-10',
-    startTime: '18:00',
-    endTime: '21:00',
-    location: 'Royal Oak, MI',
-    venue: 'Royal Starr Arts Institute',
+    location: 'Metro Detroit, MI',
+    venue: 'TBD (Royal Starr posts details monthly)',
     url: 'https://www.royalstarr.org',
-    description: 'Second-Tuesday mixer for Metro Detroit filmmakers. Date follows the posted monthly pattern — confirm ahead.'
+    description: 'Royal Starr indicates a 2nd-Tuesday mixer cadence (Jan–Oct). Confirm exact venue/time on the official RSVP/listing.',
+    verification: 'cadence (date derived; details TBD)'
   },
   {
-    id: 'royal-starr-mixer-2026-03',
+    id: 'royal-starr-mixer-2026-03-10',
     title: 'Royal Starr Filmmaker Community Mixer',
     type: 'meetup',
     startDate: '2026-03-10',
-    startTime: '18:00',
-    endTime: '21:00',
-    location: 'Royal Oak, MI',
-    venue: 'Royal Starr Arts Institute',
+    location: 'Metro Detroit, MI',
+    venue: 'TBD (Royal Starr posts details monthly)',
     url: 'https://www.royalstarr.org',
-    description: 'Royal Starr monthly mixer (calculated from their 2nd Tuesday schedule). Confirm ahead.'
+    description: 'Royal Starr indicates a 2nd-Tuesday mixer cadence (Jan–Oct). Confirm exact venue/time on the official RSVP/listing.',
+    verification: 'cadence (date derived; details TBD)'
   },
   {
-    id: 'campfire-animation-2026',
-    title: 'In Motion: Animation on Film',
+    id: 'campfire-in-motion-2026-01-15',
+    title: 'In Motion (Part 1 of 3): Animation on Film',
     type: 'workshop',
     startDate: '2026-01-15',
     startTime: '18:30',
-    location: 'Detroit, MI',
+    location: 'The Scarab Club, 217 Farnsworth St, Detroit, MI 48202',
     venue: 'The Scarab Club',
-    url: 'https://campfirefilmcoop.org/events',
-    description: 'Campfire Film Cooperative — Part 1 of 3. Hands-on look at animation on film (Scarab Club).'
+    url: 'https://campfirefilm.org/events',
+    description: 'Campfire Film Cooperative animation series kickoff: “In Motion: Animation on Film.”',
+    verification: 'verified'
+  },
+
+  // ============================================
+  // PAST EVENTS (Confirmed)
+  // ============================================
+
+  {
+    id: 'comedy-roll-kickoff-2025',
+    title: 'The Comedy Roll Kickoff 2025',
+    type: 'festival',
+    startDate: '2025-04-01',
+    startTime: '19:00',
+    endTime: '22:00',
+    location: 'Hazel Park, MI',
+    venue: 'Eastern Palace Club',
+    url: 'https://thecomedyroll.com',
+    description: 'Opening-night kickoff for The Comedy Roll: live pitches, lineup reveal, and signups for the 2025 run.',
+    verification: 'verified'
   },
   {
-    id: 'michigan-filmmakers-screening-2026',
-    title: 'Free Movie Screening at the State Theater',
+    id: 'comedy-roll-showcase-2025',
+    title: 'The Comedy Roll Showcase 2025',
     type: 'screening',
-    startDate: '2026-01-24',
-    startTime: '12:30',
-    location: 'Ann Arbor, MI',
-    venue: 'State Theater',
-    url: 'https://www.meetup.com/indie-filmmakers-ann-arbor',
-    description: 'Michigan Filmmakers & Indie Film Fans meetup — free community screening.'
+    startDate: '2025-05-20',
+    startTime: '19:00',
+    location: 'Royal Oak, MI',
+    venue: 'Emagine Royal Oak',
+    url: 'https://thecomedyroll.com',
+    description: 'Showcase screening for the 2025 Comedy Roll (per official site listing).',
+    verification: 'verified'
   },
   {
-    id: 'lab-monthly-meetup',
-    title: 'LaB Monthly Meetup',
-    type: 'meetup',
-    startDate: '2026-01-18',
-    startTime: '18:30',
-    endTime: '20:30',
-    location: 'Shelby Township, MI',
-    venue: 'Local coffee shop',
-    url: '',
-    description: 'Local LaB community meetup for collaborators and shooters.'
+    id: 'hfr-kickoff-2025',
+    title: 'Horror Film Roulette XII Kick-Off',
+    type: 'festival',
+    startDate: '2025-09-05',
+    startTime: '18:00',
+    endTime: '22:00',
+    location: 'The Scarab Club, 217 Farnsworth St, Detroit, MI 48202',
+    venue: 'The Scarab Club',
+    url: 'https://www.horrorfilmroulette.com',
+    description: 'Annual HFR competition kick-off (teams draw subgenres + begin the sprint).',
+    verification: 'verified'
   },
   {
-    id: 'oakland-workshop-2026',
-    title: 'Oakland County Production Workshop',
-    type: 'workshop',
-    startDate: '2026-03-10',
-    location: 'Troy, MI',
-    venue: 'Oakland County Studio',
-    url: '',
-    description: 'Hands-on production workflow lab in Oakland County.'
+    id: 'royal-starr-film-festival-2025',
+    title: 'Royal Starr Film Festival 2025',
+    type: 'festival',
+    startDate: '2025-09-11',
+    endDate: '2025-09-14',
+    location: 'Birmingham, MI',
+    venue: 'Emagine Birmingham 8',
+    url: 'https://filmfreeway.com/RoyalStarrFilmFestival',
+    description: 'Royal Starr Film Festival 2025 run.',
+    verification: 'verified'
+  },
+  {
+    id: 'hfr-showcase-2025',
+    title: 'Horror Film Roulette XII Showcase',
+    type: 'screening',
+    startDate: '2025-10-26',
+    startTime: '19:00',
+    location: 'Royal Oak, MI',
+    venue: 'Emagine Royal Oak',
+    url: 'https://www.horrorfilmroulette.com',
+    description: 'Big-screen showcase of the year’s HFR films.',
+    verification: 'verified'
   },
   {
     id: 'horror-film-roulette-2024',
@@ -92,7 +131,9 @@ const eventsData = [
     startTime: '18:00',
     endTime: '22:00',
     location: 'The Scarab Club, 217 Farnsworth St, Detroit, MI 48202',
+    venue: 'The Scarab Club',
     url: 'https://filmfreeway.com/HorrorFilmRoulette',
-    description: 'Horror Film Roulette is Michigan\'s unique annual horror filmmaking competition where creativity meets chance. Filmmakers spin our roulette wheel to discover their assigned theme and must create a 5-minute horror film in just 4 weeks. Compete for a $2,000 CASH grand prize and the thrill of seeing your film on the big screen!'
+    description: 'Horror Film Roulette: annual Michigan horror filmmaking competition (roulette theme draw + 4-week sprint).',
+    verification: 'verified'
   }
 ];

--- a/events.html
+++ b/events.html
@@ -402,6 +402,19 @@
             color: var(--gray-200);
         }
 
+        .tag-warning {
+            border-color: rgba(249, 115, 22, 0.5);
+            color: var(--lab-orange);
+            background: rgba(249, 115, 22, 0.12);
+        }
+
+        .tag-stack {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
         /* Event preview modal */
         .event-modal-backdrop {
             position: fixed;
@@ -557,6 +570,12 @@
             color: var(--gray-200);
             text-transform: uppercase;
             letter-spacing: 0.5px;
+        }
+
+        .status-chip--warn {
+            border-color: rgba(249, 115, 22, 0.5);
+            color: var(--lab-orange);
+            background: rgba(249, 115, 22, 0.08);
         }
 
         /* Past events */
@@ -808,6 +827,14 @@
             border-color: #A855F7;
             color: #A855F7;
             background: rgba(168, 85, 247, 0.08);
+        }
+
+        .event-modal-chip-row {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-bottom: 0.5rem;
         }
         .event-modal-body {
             padding: 2rem;
@@ -1176,7 +1203,10 @@
         <div class="event-preview-modal" id="eventPreviewModal" role="dialog" aria-modal="true" aria-labelledby="eventModalTitle" tabindex="-1">
             <div class="event-modal-header">
                 <button class="event-modal-close" id="eventModalClose" type="button">ESC</button>
-                <div id="eventModalTypeBadge" class="event-modal-type-badge"></div>
+                <div class="event-modal-chip-row">
+                    <div id="eventModalTypeBadge" class="event-modal-type-badge"></div>
+                    <span id="eventModalVerificationBadge"></span>
+                </div>
                 <h2 class="event-modal-title" id="eventModalTitle"></h2>
             </div>
             <div class="event-modal-body">
@@ -1224,12 +1254,43 @@
 
         const typeLabels = {
             meetup: 'Meetup',
-            festival: 'Festival',
+            festival: 'Film Fest',
             workshop: 'Workshop',
             screening: 'Screening',
             deadline: 'Deadline',
             other: 'Event'
         };
+
+        const getTypeLabel = (type) => typeLabels[type] || type || 'Event';
+
+        function getVerificationMeta(event) {
+            if (!event || !event.verification) return null;
+            const normalized = String(event.verification).toLowerCase();
+            if (normalized === 'verified') return null;
+
+            let label = event.verificationLabel;
+            if (!label) {
+                if (normalized.includes('tbd') || normalized.includes('announce')) {
+                    label = 'TBD';
+                } else {
+                    label = 'Check site';
+                }
+            }
+
+            const url = event.verificationUrl || event.url || '';
+            return { label, url };
+        }
+
+        function buildVerificationBadge(event, variant = 'tag') {
+            const meta = getVerificationMeta(event);
+            if (!meta) return '';
+
+            const baseClass = variant === 'chip' ? 'status-chip status-chip--warn' : 'tag tag-warning';
+            if (meta.url) {
+                return `<a class="${baseClass}" href="${meta.url}" target="_blank" rel="noopener noreferrer">${meta.label}</a>`;
+            }
+            return `<span class="${baseClass}">${meta.label}</span>`;
+        }
 
         function formatDate(dateStr) {
             if (!dateStr) return '';
@@ -1401,12 +1462,17 @@
             listContainer.innerHTML = sorted.map(ev => {
                 const isPast = isEventPast(ev);
                 const pastClass = isPast ? ' is-past' : '';
+                const typeLabel = getTypeLabel(ev.type);
+                const verificationBadge = buildVerificationBadge(ev);
                 return `
                     <div class="list-row${pastClass}" data-event-id="${ev.id}" style="cursor: pointer;">
                         <h4>${ev.title}</h4>
                         <span>${formatDate(ev.startDate)}${ev.endDate ? ' – ' + formatDate(ev.endDate) : ''}</span>
                         <span>${ev.location || 'TBD'}</span>
-                        <span class="tag">${ev.type}</span>
+                        <span class="tag-stack">
+                            <span class="tag">${typeLabel}</span>
+                            ${verificationBadge}
+                        </span>
                     </div>
                 `;
             }).join('');
@@ -1481,7 +1547,7 @@
 
                 return `
                     <div class="past-event-card type-${evt.type}" data-event-id="${evt.id}">
-                        <div class="past-event-type-badge type-${evt.type}">${evt.type}</div>
+                        <div class="past-event-type-badge type-${evt.type}">${getTypeLabel(evt.type)}</div>
                         <h3 class="past-event-title">${evt.title}</h3>
                         <div class="past-event-date">${dateRange}</div>
                         <p class="past-event-description">${evt.description || 'No description available.'}</p>
@@ -1574,11 +1640,12 @@
             ];
 
             const isPast = isEventPast(event);
+            const verificationBadge = buildVerificationBadge(event, 'chip');
             eventDescription.innerHTML = `
                 <div class="event-bio">
                     <div class="event-bio-head">
                         <div class="proto-text-mono" style="opacity:0.7;">Event Preview</div>
-                        ${isPast ? '<span class="status-chip">Past</span>' : ''}
+                        ${[isPast ? '<span class="status-chip">Past</span>' : '', verificationBadge].filter(Boolean).join('')}
                     </div>
                     <p class="event-bio-summary">${event.description || 'Details coming soon.'}</p>
                     <div class="event-bio-grid">
@@ -1719,8 +1786,16 @@
             // Set type badge
             const typeBadge = document.getElementById('eventModalTypeBadge');
             if (typeBadge) {
-                typeBadge.textContent = eventData.type;
+                const typeLabel = getTypeLabel(eventData.type);
+                typeBadge.textContent = typeLabel;
                 typeBadge.className = `event-modal-type-badge type-${eventData.type}`;
+            }
+
+            const verificationSlot = document.getElementById('eventModalVerificationBadge');
+            if (verificationSlot) {
+                const verificationBadge = buildVerificationBadge(eventData, 'chip');
+                verificationSlot.innerHTML = verificationBadge;
+                verificationSlot.style.display = verificationBadge ? 'inline-flex' : 'none';
             }
 
             // Set title with strikethrough for past events


### PR DESCRIPTION
## Summary
- refresh events-data.js with the provided Metro Detroit listings and verification metadata
- add verification badge rendering and Film Fest type label mapping across list, modal, and past views
- introduce orange warning chip/tag styling for unverified events

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae1e223888327b0d904b0cd35e786)