### PR TITLE
Replace Short Film Block Party with Fresh Coast Film Festival

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -132,3 +132,12 @@ Quick test checklist:
 - Load events page in list view: unverified Royal Starr mixers show orange badge beside type label; verified events display normally.
 - Open the Royal Starr mixer modal: badge appears near the type/status chips and links to the event site; Film Fest label shows for festival types.
 - Confirm no console errors on page load after hard refresh.
+2026-01-08 | 2:35PM EST
+———————————————————————
+Change: Replace Short Film Block Party listing with Fresh Coast Film Festival on Resources.
+Files touched: resources-data.js
+Notes: Added Fresh Coast Film Festival details with website and Instagram.
+Quick test checklist:
+- Hard refresh Resources page; confirm Fresh Coast Film Festival appears in Film Festivals list
+- Open Fresh Coast Film Festival detail view; verify website/Instagram links display
+- Console free of errors on Resources page

--- a/resources-data.js
+++ b/resources-data.js
@@ -268,13 +268,17 @@ const resources = [
         features: ['Community Screenings', 'Q&A Sessions', 'Metro Detroit', 'FilmFreeway Submissions']
     },
     {
-        name: 'Short Film Block Party',
+        name: 'Fresh Coast Film Festival',
         category: 'film-festivals',
-        desc: 'Dedicated shorts showcase built around filmmaker-friendly blocks.',
-        fullDesc: 'Short Film Block Party curates themed blocks of short films with an emphasis on discoverability and audience engagement. Filmmakers get networking time between screenings plus a straightforward FilmFreeway submission path.',
-        filmFreewayUrl: 'https://filmfreeway.com/ShortFilmBlockParty',
+        desc: 'Traverse City film festival spotlighting fresh voices and regional storytelling.',
+        fullDesc: 'Fresh Coast Film Festival in Traverse City highlights emerging and established filmmakers with a focus on community-driven screenings, filmmaker meetups, and a welcoming festival experience for audiences and creators.',
+        url: 'https://freshcoastfilmtraversecity.ludus.com/',
+        instagramUrl: 'https://www.instagram.com/freshcoastfilm',
         paid: true,
-        features: ['Short Films Only', 'Themed Blocks', 'Networking Time', 'FilmFreeway Submissions']
+        keyInfo: [
+            { label: 'Location', value: 'Traverse City, MI' }
+        ],
+        features: ['Regional Festival', 'Community Screenings', 'Filmmaker Meetups', 'Fresh Voices']
     },
 
     // ============================================


### PR DESCRIPTION
### Motivation
- Replace the outdated Short Film Block Party entry with the Fresh Coast Film Festival to reflect the current festival listing and links.
- Provide direct website and Instagram links plus a location so users can find and verify festival details quickly.
- Keep the resources dataset current and meet the repository's changelog requirement by recording the change.

### Description
- Updated the festival entry in `resources-data.js` by renaming it to "Fresh Coast Film Festival" and replacing `desc`/`fullDesc` values while adding `url`, `instagramUrl`, `keyInfo` (location), and refreshed `features`.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the replacement and including a quick manual test checklist per project rules.
- Files touched: `resources-data.js`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc08ae0f48327a80b05a15c9b88f9)