### PR TITLE
Reclassify hiring marketplaces to Tools and add Fresh Coast Film Festival to events

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -141,3 +141,12 @@ Quick test checklist:
 - Hard refresh Resources page; confirm Fresh Coast Film Festival appears in Film Festivals list
 - Open Fresh Coast Film Festival detail view; verify website/Instagram links display
 - Console free of errors on Resources page
+2026-01-08 | 2:53PM EST
+———————————————————————
+Change: Move Fiverr, Mandy, and ProductionHub into Tools and add Fresh Coast Film Festival to events data.
+Files touched: resources-data.js, events-data.js, CHANGELOG_RUNNING.md
+Notes: Reclassified hiring marketplaces under software/tools and logged Fresh Coast Film Festival with dates pending verification.
+Quick test checklist:
+- Hard refresh Resources page; filter Tools → All Tools and confirm Fiverr, Mandy, ProductionHub appear (not under Community)
+- Load Events page; find Fresh Coast Film Festival entry and open modal to confirm date range + Traverse City location display
+- Console free of errors on Resources and Events pages

--- a/events-data.js
+++ b/events-data.js
@@ -56,6 +56,18 @@ const eventsData = [
     description: 'Campfire Film Cooperative animation series kickoff: “In Motion: Animation on Film.”',
     verification: 'verified'
   },
+  {
+    id: 'fresh-coast-film-festival-2025',
+    title: 'Fresh Coast Film Festival',
+    type: 'festival',
+    startDate: '2025-10-09',
+    endDate: '2025-10-12',
+    location: 'Traverse City, MI',
+    venue: 'Traverse City venues (see official schedule)',
+    url: 'https://freshcoastfilmtraversecity.ludus.com/',
+    description: 'Traverse City festival focused on fresh voices, screenings, and community events. Confirm final schedule/times via official listings.',
+    verification: 'partial (dates to confirm)'
+  },
 
   // ============================================
   // PAST EVENTS (Confirmed)

--- a/resources-data.js
+++ b/resources-data.js
@@ -1498,7 +1498,7 @@ const resources = [
     },
     {
         name: 'Fiverr',
-        category: 'community',
+        category: 'software',
         desc: 'Freelance marketplace for creative services.',
         fullDesc: 'Find freelancers for specific tasks: logo animation, subtitles, voice-over, etc. Variable quality - vet carefully. Useful for specialized one-off needs.',
         url: 'https://www.fiverr.com',
@@ -1507,7 +1507,7 @@ const resources = [
     },
     {
         name: 'Mandy',
-        category: 'community',
+        category: 'software',
         desc: 'Crew and talent hiring platform for production.',
         fullDesc: 'Find crew, actors, and production professionals. Job postings and crew profiles. UK-focused but growing internationally. Good for finding local talent.',
         url: 'https://www.mandy.com',
@@ -1519,7 +1519,7 @@ const resources = [
     },
     {
         name: 'ProductionHub',
-        category: 'community',
+        category: 'software',
         desc: 'US-focused production job board and directory.',
         fullDesc: 'Find and post production jobs. Searchable directory of crew and vendors by location. Useful for staffing up local shoots and finding specialists.',
         url: 'https://www.productionhub.com',


### PR DESCRIPTION
### Motivation
- Fiverr, Mandy, and ProductionHub are tool/hiring platforms and should not be listed under the `community` group on the Resources page. 
- Ensure the Fresh Coast Film Festival appears on the Events page so the festival is discoverable and its dates are tracked. 

### Description
- Updated `resources-data.js` to change the `category` for `Fiverr`, `Mandy`, and `ProductionHub` from `community` to `software` so they surface under the Tools group. 
- Added a `Fresh Coast Film Festival` entry to `events-data.js` with `startDate`, `endDate`, `location`, `venue`, `url`, and a `verification` note. 
- Appended a corresponding entry to `CHANGELOG_RUNNING.md` that documents the change and includes the manual quick test checklist. 
- Files touched: `resources-data.js`, `events-data.js`, `CHANGELOG_RUNNING.md`. 

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc49962f88327949274ab0ea61691)