### PR TITLE
Add new film festival resources and update Fresh Coast entry

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -150,3 +150,13 @@ Quick test checklist:
 - Hard refresh Resources page; filter Tools → All Tools and confirm Fiverr, Mandy, ProductionHub appear (not under Community)
 - Load Events page; find Fresh Coast Film Festival entry and open modal to confirm date range + Traverse City location display
 - Console free of errors on Resources and Events pages
+2026-01-08 | 11:33AM EST
+———————————————————————
+Change: Add Ann Arbor Film Festival, Capital City Film Festival, Dancing Stars Uplifting Film Fest, and Hell’s Half Mile entries; update Fresh Coast Film Festival details for Marquette.
+Files touched: resources-data.js, CHANGELOG_RUNNING.md
+Notes: Added new festival listings with key timing/location info and refreshed Fresh Coast description.
+Quick test checklist:
+- Hard refresh Resources page; filter Film Festivals and confirm the new festival cards appear
+- Open each new festival detail view; verify website and FilmFreeway links where provided
+- Open Fresh Coast Film Festival detail view; confirm Marquette location and October timing
+- Console free of errors on Resources page

--- a/resources-data.js
+++ b/resources-data.js
@@ -199,6 +199,56 @@ const resources = [
         features: ['Ann Arbor', 'Curated Selection', 'Indie Focus', 'University Town']
     },
     {
+        name: 'Ann Arbor Film Festival (AAFF)',
+        category: 'film-festivals',
+        desc: 'Oldest experimental film festival in North America celebrating independent and avant-garde cinema.',
+        fullDesc: 'Ann Arbor Film Festival is a globally recognized festival for experimental, documentary, narrative, animation, and hybrid films. Founded in 1963, it is Academy Award®–qualifying for short films and features international submissions alongside a traveling Best of AAFF program.',
+        url: 'https://www.aafilmfest.org/',
+        filmFreewayUrl: 'https://filmfreeway.com/AAFilmFest',
+        paid: true,
+        keyInfo: [
+            { label: 'Location', value: 'Ann Arbor, MI' },
+            { label: 'Timing', value: 'Late March (annual)' }
+        ],
+        features: ['Experimental Focus', 'Academy Award Qualifying', 'International Submissions', 'Best of AAFF Tour']
+    },
+    {
+        name: 'Capital City Film Festival (CCFF)',
+        category: 'film-festivals',
+        desc: '10-day Lansing festival with screenings, mixers, and filmmaker Q&As.',
+        fullDesc: 'Capital City Film Festival in Lansing showcases a diverse mix of narrative, documentary, and experimental films alongside live events, mixers, and filmmaker Q&As. It supports both local and international artists.',
+        filmFreewayUrl: 'https://filmfreeway.com/CapitalCityFilmFestival',
+        paid: true,
+        keyInfo: [
+            { label: 'Location', value: 'Lansing, MI' },
+            { label: 'Timing', value: 'April (annual)' }
+        ],
+        features: ['Lansing', 'Live Events', 'Filmmaker Q&As', 'International & Local Mix']
+    },
+    {
+        name: 'Dancing Stars Uplifting Film Fest',
+        category: 'film-festivals',
+        desc: 'Emerging film festival focused on uplifting stories and visibility.',
+        fullDesc: 'Dancing Stars Uplifting Film Fest is a growing festival highlighted through FilmFreeway, offering visibility for uplifting and positive storytelling across short and feature formats.',
+        filmFreewayUrl: 'https://filmfreeway.com/DancingstarsUpliftingFilmFest',
+        paid: true,
+        features: ['Emerging Festival', 'Uplifting Stories', 'FilmFreeway Submissions']
+    },
+    {
+        name: 'Hell’s Half Mile Film & Music Festival',
+        category: 'film-festivals',
+        desc: 'Bay City indie film and music festival with screenings, panels, and live music.',
+        fullDesc: 'Hell’s Half Mile is a four-day independent film and music festival in downtown Bay City featuring features, shorts, live music, panels, and community networking events. Founded in 2006, it blends indie cinema with indie music culture.',
+        url: 'https://hhmfest.com/',
+        filmFreewayUrl: 'https://filmfreeway.com/HellsHalfMileFilmMusicFestival',
+        paid: true,
+        keyInfo: [
+            { label: 'Location', value: 'Bay City, MI' },
+            { label: 'Timing', value: 'Late September (annual)' }
+        ],
+        features: ['Film + Music', 'Panels & Networking', 'Downtown Bay City', 'Indie Focus']
+    },
+    {
         name: 'Horror Film Roulette',
         category: 'film-festivals',
         desc: 'Horror short film competition. Trail Dead won Best Editing 2025.',
@@ -270,15 +320,16 @@ const resources = [
     {
         name: 'Fresh Coast Film Festival',
         category: 'film-festivals',
-        desc: 'Traverse City film festival spotlighting fresh voices and regional storytelling.',
-        fullDesc: 'Fresh Coast Film Festival in Traverse City highlights emerging and established filmmakers with a focus on community-driven screenings, filmmaker meetups, and a welcoming festival experience for audiences and creators.',
-        url: 'https://freshcoastfilmtraversecity.ludus.com/',
+        desc: 'Marquette documentary festival celebrating outdoor lifestyle and Great Lakes stories.',
+        fullDesc: 'Fresh Coast Film Festival in Marquette showcases documentary films centered on outdoor lifestyles, Great Lakes storytelling, and environmental and cultural themes. The October festival pairs screenings with outdoor activities and community events.',
+        url: 'https://freshcoastfilm.com/',
         instagramUrl: 'https://www.instagram.com/freshcoastfilm',
         paid: true,
         keyInfo: [
-            { label: 'Location', value: 'Traverse City, MI' }
+            { label: 'Location', value: 'Marquette, MI' },
+            { label: 'Timing', value: 'October (third weekend)' }
         ],
-        features: ['Regional Festival', 'Community Screenings', 'Filmmaker Meetups', 'Fresh Voices']
+        features: ['Documentary Focus', 'Outdoor Lifestyle', 'Great Lakes Stories', 'Community Screenings']
     },
 
     // ============================================


### PR DESCRIPTION
### Motivation
- Expand the `Film Festivals` resources to include several regional and notable festivals for better discovery and submission links.
- Correct and localize the Fresh Coast listing to Marquette with accurate timing and site link.
- Provide FilmFreeway/website/timing/location metadata so festival detail views render useful submission info.
- Maintain project ops and traceability by appending the required changelog entry.

### Description
- Added new festival entries to `resources-data.js` for `Ann Arbor Film Festival (AAFF)`, `Capital City Film Festival (CCFF)`, `Dancing Stars Uplifting Film Fest`, and `Hell’s Half Mile Film & Music Festival`, including FilmFreeway/website links, timing, and location where available.
- Updated the `Fresh Coast Film Festival` object in `resources-data.js` to reflect Marquette, MI, October timing, updated URL, and revised description/features.
- Appended a `CHANGELOG_RUNNING.md` entry documenting the additions and a quick test checklist.
- Files touched: `resources-data.js`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdc2a915c8327a433c666691ef849)