### PR TITLE
Speed up subfilter flicker and add Community subcategories

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -169,3 +169,12 @@ Quick test checklist:
 - Load Resources page; select Community and click Events/Casting/Groups/Meetups; confirm cards filter and the subfilter label flickers faster.
 - Switch Stock/Tools/References tabs; verify subcategory button labels match the requested list and results update.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-09 | 4:07PM EST
+———————————————————————
+Change: Restore Music option in Stock subcategories to keep music filtering available on Resources.
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes: Re-added the Music subcategory button for Stock filters.
+Quick test checklist:
+- Load Resources page; select Stock and confirm Music appears alongside 3D/Fonts/Footage/SoundFX/All.
+- Click Stock → Music and verify music resources are isolated and the list updates.
+- Open DevTools console on Resources page; confirm no errors.

--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -160,3 +160,12 @@ Quick test checklist:
 - Open each new festival detail view; verify website and FilmFreeway links where provided
 - Open Fresh Coast Film Festival detail view; confirm Marquette location and October timing
 - Console free of errors on Resources page
+2026-01-09 | 2:52PM EST
+———————————————————————
+Change: Speed up Resources subcategory label flicker and align community/stock/tools/reference subcategory options with updated filter logic.
+Files touched: resources.html, resources-data.js, CHANGELOG_RUNNING.md
+Notes: Added community subcategory filtering support and refreshed subcategory button labels.
+Quick test checklist:
+- Load Resources page; select Community and click Events/Casting/Groups/Meetups; confirm cards filter and the subfilter label flickers faster.
+- Switch Stock/Tools/References tabs; verify subcategory button labels match the requested list and results update.
+- Open DevTools console on Resources page; confirm no errors.

--- a/resources-data.js
+++ b/resources-data.js
@@ -67,6 +67,7 @@ const resources = [
     {
         name: 'Royal Starr Arts Institute',
         category: 'community',
+        communityType: 'events',
         desc: 'Michigan nonprofit building filmmaker community through mixers, events, and festival programming.',
         fullDesc: 'Royal Starr Arts Institute serves Michigan\'s creative community through networking, education, and events—anchored by Royal Starr Film Festival and recurring filmmaker mixers in Metro Detroit.',
         url: 'https://www.royalstarr.org',
@@ -93,6 +94,7 @@ const resources = [
     {
         name: 'Michigan Filmmaker Community (Facebook Group)',
         category: 'community',
+        communityType: 'groups',
         desc: 'Facebook networking group for Michigan filmmakers, cast, and crew.',
         fullDesc: 'Active Facebook group for connecting Michigan filmmakers with actors, crew, and collaborators. Useful for posting gigs, staffing up, sharing resources, and finding local production support.',
         url: 'https://www.facebook.com/groups/mifilmcommunity',
@@ -126,6 +128,7 @@ const resources = [
     {
         name: 'Campfire Film Cooperative',
         category: 'community',
+        communityType: 'groups',
         desc: 'Community for filmmakers and creators—events, meetups, and crew connection.',
         fullDesc: 'Campfire Film Cooperative is a community built around connection and craft: share work, find collaborators, and show up for events designed to spark momentum and keep projects moving.',
         url: 'https://campfirefilm.org',
@@ -138,6 +141,7 @@ const resources = [
     {
         name: 'Mograph Mondays Detroit',
         category: 'community',
+        communityType: 'events',
         desc: 'Monthly Detroit meetup for motion designers, animators, and CG artists.',
         fullDesc: 'Mograph Mondays Detroit is a recurring meetup for motion designers, animators, CG artists, and adjacent creatives—an easy on-ramp to post, VFX, and design collaborators.',
         url: 'https://www.mographmondays.com/det',
@@ -149,6 +153,7 @@ const resources = [
     {
         name: 'Michigan Crew Calls',
         category: 'community',
+        communityType: 'groups',
         desc: 'Facebook group for Michigan crew opportunities and on-set needs.',
         fullDesc: 'Michigan Crew Calls is a Facebook community built for posting and finding crew gigs, last-minute hires, and on-set opportunities across the state.',
         url: 'https://www.facebook.com/groups/micrewcalls/',
@@ -158,6 +163,7 @@ const resources = [
     {
         name: 'Michigan Talent Casting',
         category: 'community',
+        communityType: 'casting',
         desc: 'Facebook group dedicated to casting calls for Michigan talent.',
         fullDesc: 'Michigan Talent Casting connects producers and directors with Michigan actors and performers—centralized casting posts and opportunities.',
         url: 'https://www.facebook.com/groups/micasting/',

--- a/resources.html
+++ b/resources.html
@@ -1870,6 +1870,7 @@
                 <button class="subfilter-btn" data-stock="3d">3D</button>
                 <button class="subfilter-btn" data-stock="fonts">Fonts</button>
                 <button class="subfilter-btn" data-stock="stock">Footage</button>
+                <button class="subfilter-btn" data-stock="music">Music</button>
                 <button class="subfilter-btn" data-stock="soundfx">SoundFX</button>
                 <button class="subfilter-btn active" data-stock="all-stock">All</button>
             </div>

--- a/resources.html
+++ b/resources.html
@@ -294,7 +294,7 @@
             font-family: 'Space Mono', monospace;
             font-size: 0.7rem;
             letter-spacing: 1px;
-            animation: labelFlicker 4s infinite;
+            animation: labelFlicker 2.5s infinite;
             color: var(--gray-600);
             text-transform: uppercase;
         }
@@ -1852,6 +1852,17 @@
             <button class="filter-btn" data-group="all">All</button>
         </div>
 
+        <!-- Community Subcategories (shown when Community is active) -->
+        <div class="subfilter-row" id="communityGroupBar" aria-live="polite" hidden>
+            <span class="subfilter-label">Community:</span>
+            <div class="subfilter-buttons">
+                <button class="subfilter-btn" data-community="events">Events</button>
+                <button class="subfilter-btn" data-community="casting">Casting</button>
+                <button class="subfilter-btn" data-community="groups">Groups/Meetups</button>
+                <button class="subfilter-btn active" data-community="all">All</button>
+            </div>
+        </div>
+
         <!-- Stock Subcategories (shown when Stock is active) -->
         <div class="subfilter-row" id="stockGroupBar" aria-live="polite" hidden>
             <span class="subfilter-label">Stock:</span>
@@ -1859,9 +1870,8 @@
                 <button class="subfilter-btn" data-stock="3d">3D</button>
                 <button class="subfilter-btn" data-stock="fonts">Fonts</button>
                 <button class="subfilter-btn" data-stock="stock">Footage</button>
-                <button class="subfilter-btn" data-stock="music">Music</button>
-                <button class="subfilter-btn" data-stock="soundfx">Sound FX</button>
-                <button class="subfilter-btn active" data-stock="all-stock">All Stock</button>
+                <button class="subfilter-btn" data-stock="soundfx">SoundFX</button>
+                <button class="subfilter-btn active" data-stock="all-stock">All</button>
             </div>
         </div>
 
@@ -1872,7 +1882,8 @@
                 <button class="subfilter-btn" data-tools="ai">AI</button>
                 <button class="subfilter-btn" data-tools="drone">Drone</button>
                 <button class="subfilter-btn" data-tools="gear">Software</button>
-                <button class="subfilter-btn active" data-tools="all-tools">All Tools</button>
+                <button class="subfilter-btn" data-tools="casting">Casting</button>
+                <button class="subfilter-btn active" data-tools="all-tools">All</button>
             </div>
         </div>
 
@@ -1885,7 +1896,6 @@
                 <button class="subfilter-btn" data-references="editing">Editing</button>
                 <button class="subfilter-btn" data-references="filming">Filming</button>
                 <button class="subfilter-btn" data-references="music">Music</button>
-                <button class="subfilter-btn" data-references="references">References</button>
                 <button class="subfilter-btn" data-references="comedy">Comedy</button>
                 <button class="subfilter-btn active" data-references="all">All</button>
             </div>
@@ -2020,6 +2030,8 @@
         const filters = document.querySelectorAll('.filter-btn');
 
         // Subfilter bars and buttons
+        const communityGroupBar = document.getElementById('communityGroupBar');
+        const communityGroupButtons = communityGroupBar ? communityGroupBar.querySelectorAll('.subfilter-btn') : [];
         const stockGroupBar = document.getElementById('stockGroupBar');
         const stockGroupButtons = stockGroupBar ? stockGroupBar.querySelectorAll('.subfilter-btn') : [];
         const toolsGroupBar = document.getElementById('toolsGroupBar');
@@ -2058,6 +2070,7 @@
 
         // Current filter state
         let currentGroup = 'film-festivals';
+        let communitySubcategory = 'all';
         let stockSubcategory = 'all-stock';
         let toolsSubcategory = 'all-tools';
         let referencesSubcategory = 'all';
@@ -2413,7 +2426,11 @@
             const primary = cats[0];
             if (currentGroup === 'all') return true;
             if (currentGroup === 'film-festivals') return cats.includes('film-festivals');
-            if (currentGroup === 'community') return cats.includes('community');
+            if (currentGroup === 'community') {
+                if (!cats.includes('community')) return false;
+                if (communitySubcategory === 'all') return true;
+                return normalizeValue(resource.communityType) === normalizeValue(communitySubcategory);
+            }
             if (currentGroup === 'collaborators') return cats.includes('collaborators');
             if (currentGroup === 'references') {
                 const matchesCategory = cats.includes('references');
@@ -2432,7 +2449,7 @@
             }
 
             if (currentGroup === 'tools') {
-                const toolCats = ['ai', 'software', 'equipment'];
+                const toolCats = ['ai', 'software', 'equipment', 'casting'];
                 if (!cats.some(c => toolCats.includes(c))) return false;
                 if (toolsSubcategory === 'all-tools') return true;
                 if (toolsSubcategory === 'gear') return cats.includes('equipment');
@@ -2663,11 +2680,15 @@
         }
 
         function renderResources(animate = false) {
+            const isCommunity = currentGroup === 'community';
             const isStock = currentGroup === 'stock';
             const isTools = currentGroup === 'tools';
             const isReferences = currentGroup === 'references';
             const isDrones = currentGroup === 'drones';
 
+            if (communityGroupBar) {
+                communityGroupBar.toggleAttribute('hidden', !isCommunity);
+            }
             if (stockGroupBar) {
                 stockGroupBar.toggleAttribute('hidden', !isStock);
             }
@@ -3096,6 +3117,10 @@
                 stockSubcategory = 'all-stock';
                 stockGroupButtons.forEach(b => b.classList.toggle('active', b.dataset.stock === stockSubcategory));
             }
+            if (newGroup !== 'community') {
+                communitySubcategory = 'all';
+                communityGroupButtons.forEach(b => b.classList.toggle('active', b.dataset.community === communitySubcategory));
+            }
             if (newGroup !== 'tools') {
                 toolsSubcategory = 'all-tools';
                 toolsGroupButtons.forEach(b => b.classList.toggle('active', b.dataset.tools === toolsSubcategory));
@@ -3140,6 +3165,16 @@
                 });
             });
         }
+
+        communityGroupButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                if (btn.classList.contains('active')) return;
+                communityGroupButtons.forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                communitySubcategory = btn.dataset.community;
+                renderResources(true);
+            });
+        });
 
         stockGroupButtons.forEach(btn => {
             btn.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Make the Subcategory label flicker more noticeable by increasing its tempo without changing visual style. 
- Provide Community subfilters so Community resources can be filtered by Events/Casting/Groups/Meetups. 
- Align Stock/Tools/References subcategory labels and behavior with the requested lists. 
- Keep changes minimal and avoid introducing new dependencies or UI duplication.

### Description
- Reduced the `.subfilter-label` animation period from `4s` to `2.5s` in `resources.html` to speed up the flicker. 
- Added a Community subfilter bar (`#communityGroupBar`) with buttons for `Events`, `Casting`, `Groups/Meetups`, and `All`, and wired up event handlers to update `communitySubcategory` and re-render results in `resources.html`. 
- Updated Stock/Tools/References subfilter button labels and ordering in `resources.html` and extended the filtering logic to recognize the new `communitySubcategory` and `casting` tool category. 
- Tagged several community entries in `resources-data.js` with `communityType` values (`events`, `casting`, `groups`) to back the new subfilters and appended an entry to `CHANGELOG_RUNNING.md` listing the change.

### Testing
- Automated tests: Not run (environment restriction). 
- Manual verification checklist appended to `CHANGELOG_RUNNING.md` (see the new `2026-01-09 | 2:52PM EST` entry).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696115b1d43083279d6dc6319ca1bc01)