### PR TITLE
Add Betaflight to Tools → Drone filters

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -178,3 +178,12 @@ Quick test checklist:
 - Load Resources page; select Stock and confirm Music appears alongside 3D/Fonts/Footage/SoundFX/All.
 - Click Stock → Music and verify music resources are isolated and the list updates.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-09 | 11:41PM EST
+———————————————————————
+Change: Add Betaflight to Tools → Drone filters in Resources.
+Files touched: resources-data.js, CHANGELOG_RUNNING.md
+Notes: Tagged Betaflight with software category so it appears under Tools → Drone.
+Quick test checklist:
+- Open resources.html; select Tools → Drone and confirm Betaflight appears in the list.
+- Use the search bar to find Betaflight; confirm it still opens the resource modal.
+- Open DevTools console on Resources page; confirm no errors.

--- a/resources-data.js
+++ b/resources-data.js
@@ -679,7 +679,7 @@ const resources = [
     },
     {
         name: 'Betaflight',
-        category: 'drone',
+        category: ['drone', 'software'],
         droneType: 'software',
         desc: 'Open-source flight controller firmware for FPV drones.',
         fullDesc: 'Betaflight is the industry-standard open-source flight controller firmware for FPV racing and freestyle drones. Offers precise tuning, configurator software, and active development—essential for custom builds and performance optimization.',


### PR DESCRIPTION
### Motivation
- Ensure Betaflight appears when users filter Resources by Tools → Drone so firmware/software references are discoverable.
- The existing entry had only the `drone` category which prevented it from being included under the Tools → Drone view.
- Keep changes minimal and data-only to avoid UI regressions on the static site.
- Follow project ops by recording the change in the running changelog (`CHANGELOG_RUNNING.md`).

### Description
- Update `resources-data.js` to change Betaflight's `category` from `'drone'` to `['drone','software']` so it matches Tools → Drone filtering rules.
- No UI, layout, or behavior code was modified; filtering logic remains unchanged and will now include Betaflight in the Tools → Drone scope.
- Append a new entry to `CHANGELOG_RUNNING.md` recording the change and quick test checklist as required by project guidelines.
- Files touched: `resources-data.js`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d833fbc083278b3ffa8c0ab5e244)