### PR TITLE
Allow YouTube iframe embeds on portfolio page (CSP update)

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -857,3 +857,11 @@ Quick test checklist:
 - Open resources.html; select Tools → Drone and confirm Betaflight appears in the list.
 - Use the search bar to find Betaflight; confirm it still opens the resource modal.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-11 | 10:45PM EST
+———————————————————————
+Change: Allow YouTube iframe embeds in the portfolio page CSP for thumbnail-to-iframe playback.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Added frame-src permissions for YouTube domains while leaving the rest of the CSP intact.
+Quick test checklist:
+- Open portfolio.html; click a video thumbnail and confirm the YouTube player loads and playback starts.
+- Open DevTools console on portfolio.html; confirm no CSP errors.

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
     <title>Work | LaB Media</title>
     <link rel="canonical" href="https://labmedia.work/portfolio.html">
 


### PR DESCRIPTION
### Motivation
- The portfolio page uses YouTube thumbnail-to-iframe playback which was blocked by the existing CSP, preventing inline iframe players from loading.
- The intent is to permit YouTube player frames while keeping the site-wide CSP restrictions intact and minimal.

### Description
- Added a `frame-src` directive to the `Content-Security-Policy` meta in `portfolio.html` allowing `https://www.youtube.com` and `https://www.youtube-nocookie.com`.
- Kept all existing CSP directives unchanged (scripts, styles, fonts, images, connect sources remain the same).
- Appended a changelog entry to `CHANGELOG_RUNNING.md` documenting the change and providing a quick test checklist.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696427f0e7988327aabd51fc3b29299b)