### PR TITLE
Fix resources filter accent selectors to use `data-group`

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -857,3 +857,12 @@ Quick test checklist:
 - Open resources.html; select Tools → Drone and confirm Betaflight appears in the list.
 - Use the search bar to find Betaflight; confirm it still opens the resource modal.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-11 | 10:45PM EST
+———————————————————————
+Change: Align Resources filter button selectors with data-group attributes so accent colors render correctly.
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes: Updated category selectors (including drones) to match the filter button data-group values.
+Quick test checklist:
+- Open resources.html; click each top filter (Film Festivals, Community, Stock, Tools, Friends, References, Drones, All) and confirm the accent color shows in the default and active states.
+- Toggle between multiple filters and confirm the active styling transitions cleanly without lingering colors.
+- Open DevTools console on resources.html; confirm no errors.

--- a/resources.html
+++ b/resources.html
@@ -268,35 +268,35 @@
         .filter-btn.active::before { left: 0; }
         
         /* Special filter buttons */
-        .filter-btn[data-category="collaborators"] { border-color: var(--lab-orange); color: var(--lab-orange); }
-        .filter-btn[data-category="collaborators"]:hover { background: rgba(249, 115, 22, 0.1); }
-        .filter-btn[data-category="collaborators"].active { background: var(--lab-orange); border-color: var(--lab-orange); color: var(--black); }
-        .filter-btn[data-category="collaborators"].active::before { background: var(--lab-orange); }
+        .filter-btn[data-group="collaborators"] { border-color: var(--lab-orange); color: var(--lab-orange); }
+        .filter-btn[data-group="collaborators"]:hover { background: rgba(249, 115, 22, 0.1); }
+        .filter-btn[data-group="collaborators"].active { background: var(--lab-orange); border-color: var(--lab-orange); color: var(--black); }
+        .filter-btn[data-group="collaborators"].active::before { background: var(--lab-orange); }
 
-        .filter-btn[data-category="community"] { border-color: var(--lab-green); color: var(--lab-green); }
-        .filter-btn[data-category="community"]:hover { background: rgba(34, 197, 94, 0.1); }
-        .filter-btn[data-category="community"].active { background: var(--lab-green); border-color: var(--lab-green); color: var(--black); }
-        .filter-btn[data-category="community"].active::before { background: var(--lab-green); }
+        .filter-btn[data-group="community"] { border-color: var(--lab-green); color: var(--lab-green); }
+        .filter-btn[data-group="community"]:hover { background: rgba(34, 197, 94, 0.1); }
+        .filter-btn[data-group="community"].active { background: var(--lab-green); border-color: var(--lab-green); color: var(--black); }
+        .filter-btn[data-group="community"].active::before { background: var(--lab-green); }
 
-        .filter-btn[data-category="film-festivals"] { border-color: #F59E0B; color: #F59E0B; }
-        .filter-btn[data-category="film-festivals"]:hover { background: rgba(245, 158, 11, 0.08); }
-        .filter-btn[data-category="film-festivals"].active { background: #F59E0B; border-color: #F59E0B; color: var(--black); }
-        .filter-btn[data-category="film-festivals"].active::before { background: #F59E0B; }
+        .filter-btn[data-group="film-festivals"] { border-color: #F59E0B; color: #F59E0B; }
+        .filter-btn[data-group="film-festivals"]:hover { background: rgba(245, 158, 11, 0.08); }
+        .filter-btn[data-group="film-festivals"].active { background: #F59E0B; border-color: #F59E0B; color: var(--black); }
+        .filter-btn[data-group="film-festivals"].active::before { background: #F59E0B; }
 
-        .filter-btn[data-category="inspiration"] { border-color: var(--lab-purple); color: var(--lab-purple); }
-        .filter-btn[data-category="inspiration"]:hover { background: rgba(168, 85, 247, 0.1); }
-        .filter-btn[data-category="inspiration"].active { background: var(--lab-purple); border-color: var(--lab-purple); color: var(--white); }
-        .filter-btn[data-category="inspiration"].active::before { background: var(--lab-purple); }
+        .filter-btn[data-group="inspiration"] { border-color: var(--lab-purple); color: var(--lab-purple); }
+        .filter-btn[data-group="inspiration"]:hover { background: rgba(168, 85, 247, 0.1); }
+        .filter-btn[data-group="inspiration"].active { background: var(--lab-purple); border-color: var(--lab-purple); color: var(--white); }
+        .filter-btn[data-group="inspiration"].active::before { background: var(--lab-purple); }
 
-        .filter-btn[data-category="drone"] { border-color: #06B6D4; color: #06B6D4; }
-        .filter-btn[data-category="drone"]:hover { background: rgba(6, 182, 212, 0.1); }
-        .filter-btn[data-category="drone"].active { background: #06B6D4; border-color: #06B6D4; color: var(--black); }
-        .filter-btn[data-category="drone"].active::before { background: #06B6D4; }
+        .filter-btn[data-group="drones"] { border-color: #06B6D4; color: #06B6D4; }
+        .filter-btn[data-group="drones"]:hover { background: rgba(6, 182, 212, 0.1); }
+        .filter-btn[data-group="drones"].active { background: #06B6D4; border-color: #06B6D4; color: var(--black); }
+        .filter-btn[data-group="drones"].active::before { background: #06B6D4; }
 
-        .filter-btn[data-category="references"] { border-color: #EC4899; color: #EC4899; }
-        .filter-btn[data-category="references"]:hover { background: rgba(236, 72, 153, 0.1); }
-        .filter-btn[data-category="references"].active { background: #EC4899; border-color: #EC4899; color: var(--white); }
-        .filter-btn[data-category="references"].active::before { background: #EC4899; }
+        .filter-btn[data-group="references"] { border-color: #EC4899; color: #EC4899; }
+        .filter-btn[data-group="references"]:hover { background: rgba(236, 72, 153, 0.1); }
+        .filter-btn[data-group="references"].active { background: #EC4899; border-color: #EC4899; color: var(--white); }
+        .filter-btn[data-group="references"].active::before { background: #EC4899; }
         
         /* ============================================
            RESOURCES GRID - ADAPTIVE COLUMN SYSTEM


### PR DESCRIPTION
### Motivation
- Fix a mismatch between CSS selectors and the filter buttons so accent colors render for each top-level filter.
- Normalize category naming for the drone filter to match the existing markup (`drones`) and prevent styling gaps.
- Keep the change minimal and surgical to preserve the prototype aesthetic and avoid UI duplication.
- Record the change in the running changelog as required by project rules.

### Description
- Replaced `.filter-btn[data-category="..."]` selectors with `.filter-btn[data-group="..."]` in `resources.html` so CSS targets the actual button attributes.
- Updated the drone selector to `data-group="drones"` to match the buttons in the DOM.
- Files touched: `resources.html` and `CHANGELOG_RUNNING.md`.
- Appended a changelog entry describing the styling alignment and verification checklist.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696427e4e3148327852312b37c423f48)