### PR TITLE
Ensure single default active subfilter in resources filters

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -857,3 +857,12 @@ Quick test checklist:
 - Open resources.html; select Tools → Drone and confirm Betaflight appears in the list.
 - Use the search bar to find Betaflight; confirm it still opens the resource modal.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-11 | 10:45PM EST
+———————————————————————
+Change: Ensure Stock and Tools subfilter rows default to a single active selection.
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes: Removed duplicate active states so each subfilter row starts with one default option.
+Quick test checklist:
+- Open resources.html; confirm each subfilter row shows a single active button by default.
+- Toggle Stock and Tools subfilters; verify only one button remains active at a time.
+- Open DevTools console on Resources page; confirm no errors.

--- a/resources.html
+++ b/resources.html
@@ -1845,7 +1845,7 @@
         <div class="subfilter-row" id="stockGroupBar" aria-live="polite" hidden>
             <span class="subfilter-label">Stock:</span>
             <div class="subfilter-buttons">
-                <button class="subfilter-btn active" data-stock="3d">3D</button>
+                <button class="subfilter-btn" data-stock="3d">3D</button>
                 <button class="subfilter-btn" data-stock="fonts">Fonts</button>
                 <button class="subfilter-btn" data-stock="stock">Footage</button>
                 <button class="subfilter-btn" data-stock="music">Music</button>
@@ -1858,7 +1858,7 @@
         <div class="subfilter-row" id="toolsGroupBar" aria-live="polite" hidden>
             <span class="subfilter-label">Tools:</span>
             <div class="subfilter-buttons">
-                <button class="subfilter-btn active" data-tools="ai">AI</button>
+                <button class="subfilter-btn" data-tools="ai">AI</button>
                 <button class="subfilter-btn" data-tools="drone">Drone</button>
                 <button class="subfilter-btn" data-tools="gear">Software</button>
                 <button class="subfilter-btn" data-tools="casting">Casting</button>


### PR DESCRIPTION
### Motivation
- Ensure each Resources subfilter row loads with exactly one highlighted choice to meet the acceptance criteria.
- Prevent ambiguous/duplicate active states in the Stock and Tools subfilter rows which caused two buttons to appear selected.
- Keep the UX consistent by preferring the `All` option as the single default for multi-option subfilter rows.

### Description
- Removed duplicate `active` classes in `resources.html` so `stock` and `tools` subfilter rows only have `All` as the default active button.
- Edited `resources.html` and appended a new entry to `CHANGELOG_RUNNING.md` to record the change.
- Files touched: `resources.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696427eb8db48327ad3cc6217a295ba1)