### PR TITLE
Fix portfolio video embed loading for MOZ aspect wrapper

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -965,3 +965,12 @@ Quick test checklist:
 - Open resources.html; select Tools → Drone and confirm Betaflight appears in the list.
 - Use the search bar to find Betaflight; confirm it still opens the resource modal.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-12 | 3:46AM EST
+———————————————————————
+Change: Fix portfolio video embeds to load inside the correct aspect wrapper so click-to-play works on all sections.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Updated the video loader to target the MOZ aspect wrapper when present.
+Quick test checklist:
+- Open portfolio.html; click each video thumbnail and confirm the YouTube player loads and plays in place.
+- Resize the browser and confirm MOZ video maintains its 16:9 frame while playing.
+- Open DevTools console on portfolio.html; confirm no errors.

--- a/portfolio.html
+++ b/portfolio.html
@@ -1269,8 +1269,9 @@
             iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
             iframe.allowFullscreen = true;
             iframe.loading = 'lazy';
-            container.innerHTML = '';
-            container.appendChild(iframe);
+            const target = container.querySelector('.video-aspect-wrapper') || container;
+            target.innerHTML = '';
+            target.appendChild(iframe);
         }
 
         document.querySelectorAll('.video-container').forEach(container => {


### PR DESCRIPTION
### Motivation
- Restore click-to-play behavior on portfolio video thumbnails that stopped working after the recent overhaul.
- Ensure videos in the `#moz` section keep their 16:9 aspect wrapper (`.video-aspect-wrapper`) when loaded so the layout remains correct.
- Make a minimal, surgical fix that does not alter UI design or add dependencies.
- Record the fix in the running changelog as required by project rules.

### Description
- Change `loadVideo` in `portfolio.html` to target an inner `.video-aspect-wrapper` when present using `const target = container.querySelector('.video-aspect-wrapper') || container;` and insert the iframe into `target`.
- Preserve iframe attributes (`autoplay`, `rel=0`, `loading='lazy'`, and `allowFullscreen`) as before to keep playback behavior consistent.
- Files changed: `portfolio.html`, `CHANGELOG_RUNNING.md`.
- No additional UI elements or dependencies were introduced.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646e67a8288327a647d5b8e71b51dc)