### PR TITLE
Allow selecting a single prompt on Ideas page

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -974,3 +974,13 @@ Quick test checklist:
 - Open portfolio.html; click each video thumbnail and confirm the YouTube player loads and plays in place.
 - Resize the browser and confirm MOZ video maintains its 16:9 frame while playing.
 - Open DevTools console on portfolio.html; confirm no errors.
+2026-01-11 | 10:55PM EST
+———————————————————————
+Change: Let a single selected prompt populate the Current Results list instead of showing all three.
+Files touched: ideas.html, CHANGELOG_RUNNING.md
+Notes: Added prompt selection handling so choosing a card isolates it in the results while keeping bonus and mini rolls.
+Quick test checklist:
+- Open ideas.html; click Roll the Die and confirm three prompts appear.
+- Click one prompt card; confirm Current Results shows only the selected prompt plus any bonus/quick rolls.
+- Roll a bonus and a quick roller; confirm they appear alongside the selected prompt.
+- Open DevTools console on ideas.html; confirm no errors.

--- a/ideas.html
+++ b/ideas.html
@@ -328,11 +328,21 @@
             border: 1px solid var(--gray-800);
             padding: 2rem;
             transition: all 0.4s ease;
+            cursor: pointer;
         }
 
         .prompt-card:hover {
             background: rgba(255, 255, 255, 0.04);
             border-color: var(--gray-600);
+        }
+
+        .prompt-card.is-selected {
+            border-color: var(--white);
+            background: rgba(255, 255, 255, 0.06);
+        }
+
+        .prompt-card.is-selected .prompt-number {
+            color: var(--gray-600);
         }
 
         .prompt-number {
@@ -1080,6 +1090,8 @@
         // ============================================
         const resultsState = {
             prompts: [],
+            generatedPrompts: [],
+            selectedPromptIndex: null,
             bonus: null,
             miniRollers: {
                 places: null,
@@ -1155,6 +1167,9 @@
             prompts.forEach((prompt, index) => {
                 const card = document.createElement('div');
                 card.className = 'prompt-card proto-corners';
+                card.dataset.promptIndex = index;
+                card.setAttribute('role', 'button');
+                card.setAttribute('tabindex', '0');
 
                 let flavorHTML = '';
                 if (prompt.genre || prompt.visualStyle || prompt.emotion) {
@@ -1191,6 +1206,17 @@
                     </div>
                     ${flavorHTML}
                 `;
+
+                card.addEventListener('click', () => {
+                    selectPrompt(index);
+                });
+
+                card.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        selectPrompt(index);
+                    }
+                });
 
                 grid.appendChild(card);
             });
@@ -1248,7 +1274,9 @@
                 renderPrompts(prompts);
 
                 // Save to state
+                resultsState.generatedPrompts = prompts;
                 resultsState.prompts = prompts;
+                resultsState.selectedPromptIndex = null;
                 updateResultsDisplay();
 
                 // Show prompts container
@@ -1401,6 +1429,20 @@
             resultsContent.innerHTML = html;
         }
 
+        function selectPrompt(index) {
+            const selected = resultsState.generatedPrompts[index];
+            if (!selected) return;
+
+            resultsState.prompts = [selected];
+            resultsState.selectedPromptIndex = index;
+            updateResultsDisplay();
+
+            document.querySelectorAll('.prompt-card').forEach((card) => {
+                const cardIndex = Number(card.dataset.promptIndex);
+                card.classList.toggle('is-selected', cardIndex === index);
+            });
+        }
+
         function generatePDF() {
             if (!hasAnyResults()) return;
 
@@ -1547,6 +1589,8 @@
 
         function clearResults() {
             resultsState.prompts = [];
+            resultsState.generatedPrompts = [];
+            resultsState.selectedPromptIndex = null;
             resultsState.bonus = null;
             resultsState.miniRollers = {
                 places: null,


### PR DESCRIPTION
### Motivation
- Users generating ideas saw all three generated prompts appear in the Current Results when they intended to pick a single prompt, so the UI needs a way to select and isolate one prompt while preserving bonus and quick-roll results.

### Description
- Add selection state to `resultsState` (`generatedPrompts` and `selectedPromptIndex`) and persist generated prompts when rolling via `handleMainRoll` so a single prompt can be isolated.
- Render prompt cards with `data-prompt-index`, keyboard support, and click handlers that call a new `selectPrompt` function which sets `resultsState.prompts` to the chosen prompt and toggles the `.is-selected` class.
- Add CSS for clickable prompt cards and a `.prompt-card.is-selected` style, and reset `generatedPrompts`/`selectedPromptIndex` in `clearResults` so selection is cleared on reset.
- Update `CHANGELOG_RUNNING.md` with the required entry documenting the change and list of files touched (`ideas.html`, `CHANGELOG_RUNNING.md`).

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification checklist has been appended to `CHANGELOG_RUNNING.md` and includes rolling prompts, selecting a card, rolling bonus/quick rollers, and confirming results display.
- Confirm no console errors on `ideas.html` using DevTools during manual testing.
- Files changed: `ideas.html`, `CHANGELOG_RUNNING.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696470555bac83279b13954bbc144c32)