### PR TITLE
Add 'Select One' hint and per-tile Clear buttons for Quick Rollers

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -984,3 +984,12 @@ Quick test checklist:
 - Click one prompt card; confirm Current Results shows only the selected prompt plus any bonus/quick rolls.
 - Roll a bonus and a quick roller; confirm they appear alongside the selected prompt.
 - Open DevTools console on ideas.html; confirm no errors.
+2026-01-12 | 4:14AM EST
+———————————————————————
+Change: Add select-one cue above prompts and per-tile clear actions for Quick Rollers.
+Files touched: ideas.html, CHANGELOG_RUNNING.md
+Notes: Added a subtle "Select One" hint and clear buttons for each mini roller tile.
+Quick test checklist:
+- Open ideas.html; click Roll the Die and confirm "Select One" appears between the header and Roll Again button.
+- In Quick Rollers, click Roll on a tile and then Clear; confirm that tile resets to "Click roll to reveal..." and Current Results updates.
+- Open DevTools console on ideas.html; confirm no errors.

--- a/ideas.html
+++ b/ideas.html
@@ -282,6 +282,7 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            gap: 1rem;
             margin-bottom: 1rem;
             padding-bottom: 1rem;
             border-bottom: 1px solid var(--gray-800);
@@ -292,6 +293,14 @@
             font-size: 0.7rem;
             color: var(--gray-600);
             letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .prompts-hint {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.6rem;
+            color: var(--gray-600);
+            letter-spacing: 1.5px;
             text-transform: uppercase;
         }
 
@@ -306,6 +315,7 @@
             text-transform: uppercase;
             cursor: pointer;
             transition: all 0.3s ease;
+            margin-left: auto;
         }
 
         .roll-again-btn:hover {
@@ -574,6 +584,29 @@
             text-transform: uppercase;
             cursor: pointer;
             transition: all 0.3s ease;
+        }
+
+        .mini-roller-actions {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .mini-clear-btn {
+            padding: 0.5rem 1rem;
+            background: transparent;
+            border: 1px solid var(--gray-800);
+            color: var(--gray-600);
+            font-family: 'Space Mono', monospace;
+            font-size: 0.6rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .mini-clear-btn:hover {
+            border-color: var(--gray-600);
+            color: var(--gray-400);
         }
 
         .mini-roll-btn:hover {
@@ -937,6 +970,7 @@
             <div class="prompts-container" id="promptsContainer">
                 <div class="prompts-header">
                     <span class="prompts-title">Your Prompts</span>
+                    <span class="prompts-hint">Select One</span>
                     <button class="roll-again-btn" id="rollAgainBtn">Roll Again</button>
                 </div>
                 <div class="prompts-grid" id="promptsGrid">
@@ -982,7 +1016,10 @@
                         <span class="mini-roller-icon">&#x1F3E0;</span>
                         <span class="mini-roller-label">Place</span>
                     </div>
-                    <button class="mini-roll-btn" data-type="places">Roll</button>
+                    <div class="mini-roller-actions">
+                        <button class="mini-roll-btn" data-type="places">Roll</button>
+                        <button class="mini-clear-btn" data-type="places">Clear</button>
+                    </div>
                     <div class="mini-roller-result empty" data-result="places">Click roll to reveal...</div>
                 </div>
 
@@ -994,7 +1031,10 @@
                         <span class="mini-roller-icon">&#x1F511;</span>
                         <span class="mini-roller-label">Object</span>
                     </div>
-                    <button class="mini-roll-btn" data-type="objects">Roll</button>
+                    <div class="mini-roller-actions">
+                        <button class="mini-roll-btn" data-type="objects">Roll</button>
+                        <button class="mini-clear-btn" data-type="objects">Clear</button>
+                    </div>
                     <div class="mini-roller-result empty" data-result="objects">Click roll to reveal...</div>
                 </div>
 
@@ -1006,7 +1046,10 @@
                         <span class="mini-roller-icon">&#x1F464;</span>
                         <span class="mini-roller-label">Character</span>
                     </div>
-                    <button class="mini-roll-btn" data-type="characters">Roll</button>
+                    <div class="mini-roller-actions">
+                        <button class="mini-roll-btn" data-type="characters">Roll</button>
+                        <button class="mini-clear-btn" data-type="characters">Clear</button>
+                    </div>
                     <div class="mini-roller-result empty" data-result="characters">Click roll to reveal...</div>
                 </div>
 
@@ -1018,7 +1061,10 @@
                         <span class="mini-roller-icon">&#x1F3AC;</span>
                         <span class="mini-roller-label">Genre</span>
                     </div>
-                    <button class="mini-roll-btn" data-type="genres">Roll</button>
+                    <div class="mini-roller-actions">
+                        <button class="mini-roll-btn" data-type="genres">Roll</button>
+                        <button class="mini-clear-btn" data-type="genres">Clear</button>
+                    </div>
                     <div class="mini-roller-result empty" data-result="genres">Click roll to reveal...</div>
                 </div>
             </div>
@@ -1312,6 +1358,8 @@
         });
 
         // Mini rollers
+        const miniPlaceholderText = 'Click roll to reveal...';
+
         document.querySelectorAll('.mini-roll-btn').forEach(btn => {
             btn.addEventListener('click', () => {
                 const type = btn.dataset.type;
@@ -1343,6 +1391,19 @@
                     resultEl.style.opacity = '1';
                     resultEl.style.transform = 'translateY(0)';
                 }, 10);
+            });
+        });
+
+        document.querySelectorAll('.mini-clear-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const type = btn.dataset.type;
+                const resultEl = document.querySelector(`[data-result="${type}"]`);
+
+                resultsState.miniRollers[type] = null;
+                updateResultsDisplay();
+
+                resultEl.classList.add('empty');
+                resultEl.textContent = miniPlaceholderText;
             });
         });
 
@@ -1606,7 +1667,7 @@
             bonusPlaceholder.style.display = '';
             document.querySelectorAll('.mini-roller-result').forEach(el => {
                 el.classList.add('empty');
-                el.textContent = 'Click roll to reveal...';
+                el.textContent = miniPlaceholderText;
             });
 
             updateResultsDisplay();


### PR DESCRIPTION
### Motivation
- Make it clearer that users should pick a single prompt from the generated list by adding a subtle visual cue.
- Provide a way to clear individual Quick Roller tiles without using the global Clear All, improving UX when a single mini roll is no longer wanted.
- Keep changes small and in-line with the existing prototype aesthetic and UI rules (no new dependencies or visual effects).

### Description
- Added a subtle `Select One` hint in the prompts header and adjusted header spacing so the hint sits between `Your Prompts` and the `Roll Again` button. 
- Added `Clear` buttons to each Quick Roller tile and new styles (`.mini-clear-btn`, `.mini-roller-actions`) to match the prototype typography. 
- Implemented per-tile clearing logic in JS: introduced `miniPlaceholderText`, wired `.mini-clear-btn` handlers to reset the tile UI and `resultsState.miniRollers[type]`, and reused the placeholder when clearing or on global clear. 
- Files touched: `ideas.html` and `CHANGELOG_RUNNING.md` (changelog entry appended with manual verification checklist).

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696474fe493c8327abf323738a59ac6c)