### PR TITLE
Add tone-tagged idea entries and tone-aware prompt filtering

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -993,3 +993,12 @@ Quick test checklist:
 - Open ideas.html; click Roll the Die and confirm "Select One" appears between the header and Roll Again button.
 - In Quick Rollers, click Roll on a tile and then Clear; confirm that tile resets to "Click roll to reveal..." and Current Results updates.
 - Open DevTools console on ideas.html; confirm no errors.
+2026-01-12 | 4:51AM EST
+———————————————————————
+Change: Add tone-tagged idea entries with tone-aware prompt filtering and normalization.
+Files touched: ideas-data.js, ideas.html, CHANGELOG_RUNNING.md
+Notes: Added tagging helpers and tone filtering with neutral fallback plus sample tagged concepts.
+Quick test checklist:
+- Open ideas.html; click Roll the Die and confirm three prompts render with concept/constraint/twist text.
+- Refresh and roll again; confirm prompts still generate without errors.
+- Open DevTools console on ideas.html; confirm no errors.

--- a/ideas-data.js
+++ b/ideas-data.js
@@ -1,15 +1,52 @@
 // Ideas Generator Data
 // Short film prompts, locations, objects, and characters for filmmakers
 
+const defaultIdeaTags = () => ({
+    tone: ['neutral'],
+    cast: [],
+    budget: []
+});
+
+const normalizeIdeaEntry = (entry) => {
+    if (typeof entry === 'string') {
+        return { text: entry, tags: defaultIdeaTags() };
+    }
+    const tags = entry.tags || {};
+    const tone = Array.isArray(tags.tone) && tags.tone.length ? tags.tone : ['neutral'];
+    const cast = Array.isArray(tags.cast) ? tags.cast : [];
+    const budget = Array.isArray(tags.budget) ? tags.budget : [];
+    const normalized = {
+        ...entry,
+        tags: {
+            tone,
+            cast,
+            budget
+        }
+    };
+    if (typeof tags.intensity === 'number') {
+        normalized.tags.intensity = tags.intensity;
+    }
+    return normalized;
+};
+
 const ideasData = {
     // ============================================
     // CORE CONCEPTS - Central ideas/situations
     // Evocative 1-2 sentence scenarios
     // ============================================
     concepts: [
-        "A stranger is sitting in your usual coffee shop seat. You decide to wait them out.",
-        "Someone finds a phone on a park bench with one missed call—from their own number.",
-        "Two people meet at an intersection. Both are running late to the same event, but neither knows it yet.",
+        {
+            text: "A stranger is sitting in your usual coffee shop seat. You decide to wait them out.",
+            tags: { tone: ['neutral', 'dark'], cast: ['two'], budget: ['micro'], intensity: 2 }
+        },
+        {
+            text: "A cashier is overly cheerful. The customer slowly realizes the cashier is stalling them from leaving.",
+            tags: { tone: ['horror', 'dark'], cast: ['two'], budget: ['micro'], intensity: 4 }
+        },
+        {
+            text: "Two strangers compete for the last available outlet. The fight gets intimate, fast.",
+            tags: { tone: ['comedy', 'dark'], cast: ['two'], budget: ['micro'], intensity: 3 }
+        },
         "A person rehearses the same conversation in their car before going inside. We never see who they're meeting.",
         "Someone returns to their childhood home to retrieve one specific object. The new owners let them in.",
         "A delivery driver has been circling the same block for an hour. They can't bring themselves to make this delivery.",
@@ -57,7 +94,7 @@ const ideasData = {
         "A person takes a photo of themselves. They delete it immediately. They try again.",
         "Two people make eye contact across a crowded room. One looks away. The other doesn't.",
         "A child asks a parent a question they can't answer honestly."
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // CONSTRAINTS - Rules that shape the story
@@ -103,7 +140,7 @@ const ideasData = {
         { text: "The entire story must fit in a 3-minute runtime", type: "time" },
         { text: "We only see what fits in a mirror", type: "visual" },
         { text: "The action takes place in complete silence until the final moment", type: "audio" }
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // TWISTS - Complications that reframe the story
@@ -149,7 +186,7 @@ const ideasData = {
         "The thing they're hiding is obvious to everyone but them.",
         "This isn't the beginning—it's the middle.",
         "The real story is what we don't see."
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // PLACES - Low-budget filming locations

--- a/ideas.html
+++ b/ideas.html
@@ -1124,6 +1124,39 @@
             return shuffled.slice(0, count);
         }
 
+        function normalizeIdeaEntry(entry) {
+            if (typeof entry === 'string') {
+                return { text: entry, tags: { tone: ['neutral'], cast: [], budget: [] } };
+            }
+            const tags = entry.tags || {};
+            const tone = Array.isArray(tags.tone) && tags.tone.length ? tags.tone : ['neutral'];
+            const cast = Array.isArray(tags.cast) ? tags.cast : [];
+            const budget = Array.isArray(tags.budget) ? tags.budget : [];
+            const normalized = {
+                ...entry,
+                tags: {
+                    tone,
+                    cast,
+                    budget
+                }
+            };
+            if (typeof tags.intensity === 'number') {
+                normalized.tags.intensity = tags.intensity;
+            }
+            return normalized;
+        }
+
+        function filterByTone(entries, selectedTone, minimumCount) {
+            const normalizedEntries = entries.map(normalizeIdeaEntry);
+            const filteredEntries = normalizedEntries.filter(entry =>
+                entry.tags.tone.includes(selectedTone) || entry.tags.tone.includes('neutral')
+            );
+            if (filteredEntries.length < minimumCount) {
+                return normalizedEntries;
+            }
+            return filteredEntries;
+        }
+
         // Dice face characters
         const diceFaces = ['\u2680', '\u2681', '\u2682', '\u2683', '\u2684', '\u2685'];
 
@@ -1169,34 +1202,38 @@
             const usedConcepts = new Set();
             const usedConstraints = new Set();
             const usedTwists = new Set();
+            const selectedTone = 'neutral';
+            const conceptPool = filterByTone(ideasData.concepts, selectedTone, 3);
+            const constraintPool = filterByTone(ideasData.constraints, selectedTone, 3);
+            const twistPool = filterByTone(ideasData.twists, selectedTone, 3);
 
             for (let i = 0; i < 3; i++) {
                 // Get unique concept
                 let concept;
                 do {
-                    concept = getRandomItem(ideasData.concepts);
-                } while (usedConcepts.has(concept) && usedConcepts.size < ideasData.concepts.length);
-                usedConcepts.add(concept);
+                    concept = getRandomItem(conceptPool);
+                } while (usedConcepts.has(concept.text) && usedConcepts.size < conceptPool.length);
+                usedConcepts.add(concept.text);
 
                 // Get unique constraint
                 let constraint;
                 do {
-                    constraint = getRandomItem(ideasData.constraints);
-                } while (usedConstraints.has(constraint.text) && usedConstraints.size < ideasData.constraints.length);
+                    constraint = getRandomItem(constraintPool);
+                } while (usedConstraints.has(constraint.text) && usedConstraints.size < constraintPool.length);
                 usedConstraints.add(constraint.text);
 
                 // Get unique twist
                 let twist;
                 do {
-                    twist = getRandomItem(ideasData.twists);
-                } while (usedTwists.has(twist) && usedTwists.size < ideasData.twists.length);
-                usedTwists.add(twist);
+                    twist = getRandomItem(twistPool);
+                } while (usedTwists.has(twist.text) && usedTwists.size < twistPool.length);
+                usedTwists.add(twist.text);
 
                 // Optional flavor elements (rotate, don't force all)
                 const prompt = {
-                    concept: concept,
+                    concept: concept.text,
                     constraint: constraint,
-                    twist: twist,
+                    twist: twist.text,
                     genre: Math.random() > 0.5 ? getRandomItem(ideasData.genres) : null,
                     visualStyle: Math.random() > 0.6 ? getRandomItem(ideasData.visualStyles) : null,
                     emotion: Math.random() > 0.6 ? getRandomItem(ideasData.emotions) : null,


### PR DESCRIPTION
### Motivation
- Add lightweight tagging to idea entries so prompts can be filtered by tone (e.g., `comedy`, `horror`, `neutral`) to avoid incoherent combos.
- Keep backwards compatibility so legacy string entries continue to work as neutral-tagged items.
- Provide a simple fallback when tone-filtering would produce too few options so prompt generation remains robust.

### Description
- Added normalization helpers (`defaultIdeaTags`, `normalizeIdeaEntry`) and sample tagged concepts to `ideas-data.js`, and applied `.map(normalizeIdeaEntry)` to concept/constraint/twist lists.
- Added `normalizeIdeaEntry` and `filterByTone` to `ideas.html` and changed `generatePrompts()` to build tone-filtered pools (`conceptPool`, `constraintPool`, `twistPool`) using a `selectedTone` (currently `'neutral'`).
- Updated prompt selection to use normalized objects (using `.text` where appropriate) and preserve uniqueness checks for generated prompts.
- Appended an entry to `CHANGELOG_RUNNING.md` documenting the change and manual quick test checklist.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647d4fd560832793a5c992460cfb7f)