### PR TITLE
Harden ideas data handling for object-backed entries

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1011,3 +1011,12 @@ Quick test checklist:
 - Open ideas.html; click Roll the Die and confirm new prompt text appears across concepts, constraints, and places.
 - Roll multiple times to confirm tags do not break prompt generation.
 - Open DevTools console on ideas.html; confirm no errors.
+2026-01-12 | 5:15AM EST
+———————————————————————
+Change: Make ideas UI resilient to object-backed entries and normalize extra data arrays.
+Files touched: ideas.html, ideas-data.js, CHANGELOG_RUNNING.md
+Notes: Added getEntryText usage across bonus, mini rollers, flavor display, and fixed constraint type fields.
+Quick test checklist:
+- Open ideas.html; click Roll the Die and confirm prompts render with readable flavor badges.
+- Click Bonus Roll and each mini roller; confirm results appear and Current Results updates.
+- Open DevTools console on ideas.html; confirm no errors.

--- a/ideas-data.js
+++ b/ideas-data.js
@@ -278,63 +278,78 @@ const ideasData = {
         { text: "The action takes place in complete silence until the final moment", type: "audio" },
         {
             text: "The story unfolds during a single shared task",
-            tags: { tone: ['neutral'], type: "structure" }
+            type: "structure",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "The protagonist must change their mind twice",
-            tags: { tone: ['neutral'], type: "storytelling" }
+            type: "storytelling",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "We never hear the most important line of dialogue",
-            tags: { tone: ['neutral'], type: "dialogue" }
+            type: "dialogue",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "Every scene must include an interruption",
-            tags: { tone: ['comedy'], type: "pacing" }
+            type: "pacing",
+            tags: { tone: ['comedy'] }
         },
         {
             text: "Only one character is allowed to move at a time",
-            tags: { tone: ['neutral'], type: "visual" }
+            type: "visual",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "The film must begin and end with the same action",
-            tags: { tone: ['neutral'], type: "structure" }
+            type: "structure",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "All conflict is expressed through behavior, not dialogue",
-            tags: { tone: ['neutral'], type: "storytelling" }
+            type: "storytelling",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "We only hear one side of every conversation",
-            tags: { tone: ['neutral'], type: "audio" }
+            type: "audio",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "The protagonist must teach something incorrectly at first",
-            tags: { tone: ['comedy'], type: "storytelling" }
+            type: "storytelling",
+            tags: { tone: ['comedy'] }
         },
         {
             text: "The camera never enters the main space—it observes from outside",
-            tags: { tone: ['neutral'], type: "visual" }
+            type: "visual",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "A recurring sound gains new meaning by the end",
-            tags: { tone: ['neutral'], type: "audio" }
+            type: "audio",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "Every scene must reveal a small mistake",
-            tags: { tone: ['comedy'], type: "storytelling" }
+            type: "storytelling",
+            tags: { tone: ['comedy'] }
         },
         {
             text: "The story must work without subtitles or dialogue",
-            tags: { tone: ['neutral'], type: "audio" }
+            type: "audio",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "We never see the resolution—only the choice",
-            tags: { tone: ['neutral'], type: "structure" }
+            type: "structure",
+            tags: { tone: ['neutral'] }
         },
         {
             text: "The protagonist must attempt something they’re bad at",
-            tags: { tone: ['comedy'], type: "character" }
+            type: "character",
+            tags: { tone: ['comedy'] }
         }
     ].map(normalizeIdeaEntry),
 
@@ -508,7 +523,7 @@ const ideasData = {
             text: "Closed roller rink",
             tags: { tone: ['neutral'], budget: ['micro'] }
         }
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // OBJECTS - Items to incorporate into the story
@@ -574,7 +589,7 @@ const ideasData = {
         "A coat that fits no one in the house",
         "A stack of unsent letters tied with string",
         "A wedding invitation on a refrigerator"
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // CHARACTERS - Archetypes and traits
@@ -620,7 +635,7 @@ const ideasData = {
         "A person who is generous to a fault",
         "Someone who keeps grudges in a journal",
         "A person who walks away from every fight—but remembers every word"
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // GENRES
@@ -641,7 +656,7 @@ const ideasData = {
         "Coming-of-age",
         "Mockumentary",
         "Absurdist"
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // VISUAL STYLES
@@ -662,7 +677,7 @@ const ideasData = {
         "Shallow depth of field",
         "High contrast black and white",
         "Long takes with no cuts"
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // EMOTIONAL TARGETS
@@ -683,7 +698,7 @@ const ideasData = {
         "Quiet joy",
         "Bittersweet",
         "Uncertainty"
-    ],
+    ].map(normalizeIdeaEntry),
 
     // ============================================
     // BONUS CHALLENGES - Extra points
@@ -719,7 +734,7 @@ const ideasData = {
         "A character must make a decision without all the information",
         "The weather must reflect or contrast the emotional tone",
         "Someone must be overheard saying something they shouldn't"
-    ]
+    ].map(normalizeIdeaEntry)
 };
 
 // Export for potential module use

--- a/ideas.html
+++ b/ideas.html
@@ -1112,6 +1112,13 @@
         // ============================================
         // UTILITY FUNCTIONS
         // ============================================
+        function getEntryText(entry) {
+            if (entry == null) return '';
+            if (typeof entry === 'string') return entry;
+            if (typeof entry.text === 'string') return entry.text;
+            return String(entry);
+        }
+
         function getRandomItem(array) {
             return array[Math.floor(Math.random() * array.length)];
         }
@@ -1258,13 +1265,13 @@
                 if (prompt.genre || prompt.visualStyle || prompt.emotion) {
                     flavorHTML = '<div class="prompt-flavor">';
                     if (prompt.genre) {
-                        flavorHTML += `<span class="flavor-badge genre">${prompt.genre}</span>`;
+                        flavorHTML += `<span class="flavor-badge genre">${getEntryText(prompt.genre)}</span>`;
                     }
                     if (prompt.visualStyle) {
-                        flavorHTML += `<span class="flavor-badge visual">${prompt.visualStyle}</span>`;
+                        flavorHTML += `<span class="flavor-badge visual">${getEntryText(prompt.visualStyle)}</span>`;
                     }
                     if (prompt.emotion) {
-                        flavorHTML += `<span class="flavor-badge emotion">${prompt.emotion}</span>`;
+                        flavorHTML += `<span class="flavor-badge emotion">${getEntryText(prompt.emotion)}</span>`;
                     }
                     flavorHTML += '</div>';
                 }
@@ -1376,12 +1383,13 @@
         // Bonus roll handler
         bonusRollBtn.addEventListener('click', () => {
             const bonus = getRandomItem(ideasData.bonuses);
-            bonusResult.textContent = bonus;
+            const bonusText = getEntryText(bonus);
+            bonusResult.textContent = bonusText;
             bonusResult.classList.add('visible');
             bonusPlaceholder.style.display = 'none';
 
             // Save to state
-            resultsState.bonus = bonus;
+            resultsState.bonus = bonusText;
             updateResultsDisplay();
 
             // Animate
@@ -1414,11 +1422,12 @@
                 }
 
                 // Save to state
-                resultsState.miniRollers[type] = result;
+                const resultText = getEntryText(result);
+                resultsState.miniRollers[type] = resultText;
                 updateResultsDisplay();
 
                 resultEl.classList.remove('empty');
-                resultEl.textContent = result;
+                resultEl.textContent = resultText;
 
                 // Animate
                 resultEl.style.opacity = '0';
@@ -1475,9 +1484,9 @@
                 html += '<div class="results-group-items">';
                 resultsState.prompts.forEach((prompt, idx) => {
                     let flavorHtml = '';
-                    if (prompt.genre) flavorHtml += `<span style="color: #FF8C42;">${prompt.genre}</span> `;
-                    if (prompt.visualStyle) flavorHtml += `<span style="color: #00D9FF;">${prompt.visualStyle}</span> `;
-                    if (prompt.emotion) flavorHtml += `<span style="color: #2ECC71;">${prompt.emotion}</span>`;
+                    if (prompt.genre) flavorHtml += `<span style="color: #FF8C42;">${getEntryText(prompt.genre)}</span> `;
+                    if (prompt.visualStyle) flavorHtml += `<span style="color: #00D9FF;">${getEntryText(prompt.visualStyle)}</span> `;
+                    if (prompt.emotion) flavorHtml += `<span style="color: #2ECC71;">${getEntryText(prompt.emotion)}</span>`;
 
                     html += `<div class="results-prompt-card">
                         <div class="results-prompt-number">PROMPT 0${idx + 1}</div>
@@ -1614,9 +1623,9 @@
 
                     // Flavor badges
                     let flavors = [];
-                    if (prompt.genre) flavors.push(`Genre: ${prompt.genre}`);
-                    if (prompt.visualStyle) flavors.push(`Style: ${prompt.visualStyle}`);
-                    if (prompt.emotion) flavors.push(`Emotion: ${prompt.emotion}`);
+                    if (prompt.genre) flavors.push(`Genre: ${getEntryText(prompt.genre)}`);
+                    if (prompt.visualStyle) flavors.push(`Style: ${getEntryText(prompt.visualStyle)}`);
+                    if (prompt.emotion) flavors.push(`Emotion: ${getEntryText(prompt.emotion)}`);
                     if (flavors.length > 0) {
                         doc.setFontSize(9);
                         doc.setTextColor(100);


### PR DESCRIPTION
### Motivation
- Make the ideas UI tolerant of entries that may be plain strings or object-backed entries so future normalization won't break rendering.
- Prevent runtime errors and broken displays when `bonuses` or mini-roller data become objects instead of strings.
- Future-proof flavor badge rendering and PDF export so `genre`/`visualStyle`/`emotion` never show `[object Object]`.
- Ensure constraint entries expose a top-level `type` for reliable filtering/grouping.

### Description
- Add `getEntryText(entry)` to `ideas.html` and use it when rendering flavor badges, bonus output, mini-roller results, results display, and PDF generation.
- Store text values (not raw objects) in `resultsState` for `bonus` and `miniRollers` so the UI and exports always receive strings.
- Normalize additional arrays in `ideas-data.js` (`places`, `objects`, `characters`, `genres`, `visualStyles`, `emotions`, `bonuses`) via `.map(normalizeIdeaEntry)` and move constraint `type` out of `tags` into the top-level field.
- Append the required entry to `CHANGELOG_RUNNING.md` noting the changes and quick test checklist.

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696483035bac83279e9276808bc396d5)