### PR TITLE
Allow resource video embeds by expanding CSP frame-src

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1029,3 +1029,12 @@ Quick test checklist:
 - Open ideas.html; roll prompts and confirm objects/twists/characters/bonuses include new entries.
 - In DevTools console on ideas.html, run rollIdea(ideasData, { tone: "mystery", localMode: true }) and confirm a bundle returns.
 - Open DevTools console on ideas.html; confirm no errors.
+2026-01-12 | 5:38AM EST
+———————————————————————
+Change: Allow embedded example videos to load in resource modals by expanding CSP frame sources.
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes: Added YouTube and Vimeo frame-src allowances for modal video iframes.
+Quick test checklist:
+- Open resources.html; open a resource with an Example Video (e.g., Mike Sytes) and confirm the video iframe loads.
+- Open resources.html; open another resource with a Vimeo example and confirm the video iframe loads.
+- Open DevTools console on resources.html; confirm no errors.

--- a/resources.html
+++ b/resources.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com;">
     <title>Resources | LaB Media</title>
     <link rel="canonical" href="https://labmedia.work/resources.html">
 


### PR DESCRIPTION
### Motivation
- Resource bio modals that embed Example videos (YouTube/Vimeo) stopped rendering, likely due to the page Content-Security-Policy blocking frame sources.
- The intent is to restore in-modal playback for curated videos without changing embed logic or adding dependencies.
- Keep the change minimal and surgical to avoid altering other UI behavior.

### Description
- Updated the CSP meta in `resources.html` to add `frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com` so modal iframes can load YouTube and Vimeo embeds.
- Appended an entry to `CHANGELOG_RUNNING.md` describing the change and listing manual verification steps. 
- Files touched: `resources.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964888107bc8327823ed380604ee251)