### PR TITLE
Improve resource modal video embedding (YouTube/Vimeo ID parsing)

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1038,3 +1038,12 @@ Quick test checklist:
 - Open resources.html; open a resource with an Example Video (e.g., Mike Sytes) and confirm the video iframe loads.
 - Open resources.html; open another resource with a Vimeo example and confirm the video iframe loads.
 - Open DevTools console on resources.html; confirm no errors.
+2026-01-12 | 5:51AM EST
+———————————————————————
+Change: Improve resource modal video embedding by resolving IDs from stored video fields and link URLs.
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes: Added YouTube/Vimeo ID parsing and embed fallbacks to keep video frames loading across entries.
+Quick test checklist:
+- Open resources.html; open collaborators like Anthony R Brass and confirm the embedded video renders in the modal.
+- Open resources.html; open a drone channel like Joshua Bardwell or BOTGRINDER and confirm the embedded video renders.
+- Open DevTools console on resources.html; confirm no errors.

--- a/resources.html
+++ b/resources.html
@@ -2587,6 +2587,22 @@
             return /facebook\.com/.test(url || '');
         }
 
+        function getYouTubeVideoId(value) {
+            if (!value) return '';
+            const input = String(value).trim();
+            if (/^[\w-]{11}$/.test(input)) return input;
+            const match = input.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/))([\w-]{11})/i);
+            return match ? match[1] : '';
+        }
+
+        function getVimeoVideoId(value) {
+            if (!value) return '';
+            const input = String(value).trim();
+            if (/^\d+$/.test(input)) return input;
+            const match = input.match(/vimeo\.com\/(?:video\/)?(\d+)/i);
+            return match ? match[1] : '';
+        }
+
         function getCtaPreset(type = 'website') {
             const presets = {
                 website: { variant: 'btn--outline-white', icon: '', label: 'Website' },
@@ -3102,17 +3118,20 @@
             // Video embed for inspiration, references, drone, and collaborators categories
             const isDrone = primaryCat === 'drone';
             const isReferences = primaryCat === 'references';
-            const showVideo = (isInspiration || isDrone || isReferences || isCollaborator) && (r.featuredVideo || r.vimeoVideo);
+            const videoLink = additionalLinks.find(link => link && link.type === 'video' && link.url);
+            const vimeoVideoId = getVimeoVideoId(r.vimeoVideo || (videoLink && videoLink.url));
+            const youtubeVideoId = getYouTubeVideoId(r.featuredVideo || (videoLink && videoLink.url));
+            const showVideo = (isInspiration || isDrone || isReferences || isCollaborator) && (youtubeVideoId || vimeoVideoId);
 
             let videoHTML = '';
             if (showVideo) {
                 let embedSrc = '';
-                if (r.vimeoVideo) {
+                if (vimeoVideoId) {
                     // Vimeo embed
-                    embedSrc = 'https://player.vimeo.com/video/' + r.vimeoVideo + '?title=0&byline=0&portrait=0';
-                } else if (r.featuredVideo) {
+                    embedSrc = 'https://player.vimeo.com/video/' + vimeoVideoId + '?title=0&byline=0&portrait=0';
+                } else if (youtubeVideoId) {
                     // YouTube embed
-                    embedSrc = 'https://www.youtube.com/embed/' + r.featuredVideo + '?rel=0&modestbranding=1';
+                    embedSrc = 'https://www.youtube-nocookie.com/embed/' + youtubeVideoId + '?rel=0&modestbranding=1';
                 }
 
                 if (embedSrc) {


### PR DESCRIPTION
### Motivation
- Resource modals sometimes failed to render example videos when entries used different video formats or links, so embeds need more robust ID resolution.
- Ensure collaborators, references, and drone entries reliably show embedded videos when a `featuredVideo`, `vimeoVideo`, or video `additionalLinks` URL is present.
- Prefer a privacy-friendly YouTube embed domain and avoid adding any new dependencies or UI elements.
- Record the change in the running changelog per repository workflow rules.

### Description
- Added `getYouTubeVideoId` and `getVimeoVideoId` helper functions in `resources.html` to extract IDs from raw IDs or from common YouTube/Vimeo URL patterns.
- Updated modal embed logic to look for video IDs in `r.featuredVideo`, `r.vimeoVideo`, and any `additionalLinks` with `type: 'video'`, and only render an iframe when a valid ID is found.
- Switched YouTube iframe sources to the privacy-friendly `www.youtube-nocookie.com` domain and kept Vimeo embeds via `player.vimeo.com`.
- Files touched: `resources.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).
- A Playwright headless smoke test was attempted but failed due to Chromium crashing in the execution environment, so no automated screenshot was captured.
- A manual verification checklist was appended to `CHANGELOG_RUNNING.md` that exercises opening `resources.html` and confirming video embeds for `Anthony R Brass`, `Joshua Bardwell`, and `BOTGRINDER` and checking DevTools for errors.
- Confirmed `CHANGELOG_RUNNING.md` was appended and `resources.html` contains the new ID parsing and embed logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69648a5985088327a506d526564024e4)