### PR TITLE
Cap plan budget dropdown at $5,000+

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1047,3 +1047,12 @@ Quick test checklist:
 - Open resources.html; open collaborators like Anthony R Brass and confirm the embedded video renders in the modal.
 - Open resources.html; open a drone channel like Joshua Bardwell or BOTGRINDER and confirm the embedded video renders.
 - Open DevTools console on resources.html; confirm no errors.
+2026-01-12 | 6:12AM EST
+———————————————————————
+Change: Cap plan page budget dropdown at $5,000+ as the maximum option.
+Files touched: plan-your-project.html, CHANGELOG_RUNNING.md
+Notes: Removed higher budget tiers so the max range matches the requested ceiling.
+Quick test checklist:
+- Open plan-your-project.html; verify the Budget dropdown tops out at $5,000+.
+- Select Budget options and confirm the form accepts the selection.
+- Open DevTools console on plan-your-project.html; confirm no errors.

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -1092,9 +1092,7 @@
                             <option value="$500 - $1,000">$500 - $1,000</option>
                             <option value="$1,000 - $3,000">$1,000 - $3,000</option>
                             <option value="$3,000 - $5,000">$3,000 - $5,000</option>
-                            <option value="$5,000 - $10,000">$5,000 - $10,000</option>
-                            <option value="$10,000 - $20,000">$10,000 - $20,000</option>
-                            <option value="$20,000+">$20,000+</option>
+                            <option value="$5,000+">$5,000+</option>
                             <option value="Let's discuss">Let's discuss</option>
                         </select>
                     </div>


### PR DESCRIPTION
### Motivation
- The plan page budget dropdown currently exposes very high tiers that exceed the intended maximum, so the UI should cap out at a clear $5,000+ option.
- Keep the form options simple and aligned with project pricing expectations while preserving a "Let's discuss" choice for outliers.

### Description
- Updated `plan-your-project.html` to remove the `$5,000 - $10,000`, `$10,000 - $20,000`, and `$20,000+` options and replace them with a single `$5,000+` option in the `select` with `id="budget"`.
- Appended a changelog entry to `CHANGELOG_RUNNING.md` documenting the change and adding a manual quick test checklist.
- Changes are surgical and do not introduce new dependencies or alter other UI elements.

### Testing
- `Automated tests: Not run (environment restriction)`
- Manual verification checklist is recorded in `CHANGELOG_RUNNING.md` and advises opening `plan-your-project.html` to confirm the Budget dropdown tops out at `$5,000+` and checking the DevTools console for errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696490a7b1f4832795f630d7ba281815)