### PR TITLE
Add reroll buttons for idea constraints and twists

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1065,3 +1065,12 @@ Quick test checklist:
 - Open ideas.html; trigger rolls and confirm new visual style, emotion, and bonus options appear.
 - Open ideas.html; refresh and confirm existing idea options still render.
 - Open DevTools console on ideas.html; confirm no errors.
+2026-01-12 | 11:57AM EST
+———————————————————————
+Change: Add per-prompt reroll buttons for constraints and twists on the Ideas page.
+Files touched: ideas.html, CHANGELOG_RUNNING.md
+Notes: Reroll controls update the prompt card text and results summary without changing the concept.
+Quick test checklist:
+- Open ideas.html; roll prompts, then reroll Constraint and Twist on a card and confirm the text updates in the card.
+- Select a prompt after rerolling and confirm the Current Results section reflects the updated constraint/twist.
+- Open DevTools console on ideas.html; confirm no errors.

--- a/ideas.html
+++ b/ideas.html
@@ -378,12 +378,37 @@
             gap: 0.5rem;
         }
 
+        .prompt-section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
         .prompt-label {
             font-family: 'Space Mono', monospace;
             font-size: 0.6rem;
             color: var(--gray-600);
             letter-spacing: 2px;
             text-transform: uppercase;
+        }
+
+        .prompt-reroll-btn {
+            border: 1px solid var(--gray-800);
+            background: transparent;
+            color: var(--gray-600);
+            font-family: 'Space Mono', monospace;
+            font-size: 0.55rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            padding: 0.25rem 0.6rem;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .prompt-reroll-btn:hover {
+            border-color: var(--white);
+            color: var(--white);
         }
 
         .prompt-text {
@@ -1223,18 +1248,27 @@
         // ============================================
         // PROMPT GENERATION
         // ============================================
+        const selectedTone = 'neutral';
+        const localMode = true;
+        const maxCast = localMode ? 2 : null;
+
+        function getConstraintPool() {
+            return filterByTone(ideasData.constraints, selectedTone, 3);
+        }
+
+        function getTwistPool() {
+            return filterByTone(ideasData.twists, selectedTone, 3);
+        }
+
         function generatePrompts() {
             const prompts = [];
             const usedConcepts = new Set();
             const usedConstraints = new Set();
             const usedTwists = new Set();
-            const selectedTone = 'neutral';
-            const localMode = true;
-            const maxCast = localMode ? 2 : null;
             let conceptPool = filterByTone(ideasData.concepts, selectedTone, 3);
             conceptPool = filterByMaxCast(conceptPool, maxCast);
-            const constraintPool = filterByTone(ideasData.constraints, selectedTone, 3);
-            const twistPool = filterByTone(ideasData.twists, selectedTone, 3);
+            const constraintPool = getConstraintPool();
+            const twistPool = getTwistPool();
 
             for (let i = 0; i < 3; i++) {
                 // Get unique concept
@@ -1270,6 +1304,44 @@
                 prompts.push(prompt);
             }
             return prompts;
+        }
+
+        function getDifferentItem(pool, currentText) {
+            if (!pool.length) return null;
+            let next = getRandomItem(pool);
+            let attempts = 0;
+            while (pool.length > 1 && getEntryText(next) === currentText && attempts < 10) {
+                next = getRandomItem(pool);
+                attempts++;
+            }
+            return next;
+        }
+
+        function rerollPromptField(index, field) {
+            const prompt = resultsState.generatedPrompts[index];
+            if (!prompt) return;
+
+            if (field === 'constraint') {
+                const nextConstraint = getDifferentItem(getConstraintPool(), getEntryText(prompt.constraint));
+                if (!nextConstraint) return;
+                prompt.constraint = normalizeIdeaEntryLocal(nextConstraint);
+            }
+
+            if (field === 'twist') {
+                const nextTwist = getDifferentItem(getTwistPool(), prompt.twist);
+                if (!nextTwist) return;
+                prompt.twist = getEntryText(nextTwist);
+            }
+
+            const card = document.querySelector(`.prompt-card[data-prompt-index="${index}"]`);
+            if (card && field === 'constraint') {
+                card.querySelector('.prompt-text.constraint').textContent = prompt.constraint.text;
+            }
+            if (card && field === 'twist') {
+                card.querySelector('.prompt-text.twist').textContent = prompt.twist;
+            }
+
+            updateResultsDisplay();
         }
 
         function renderPrompts(prompts) {
@@ -1308,11 +1380,17 @@
                             <p class="prompt-text concept">${prompt.concept}</p>
                         </div>
                         <div class="prompt-section">
-                            <span class="prompt-label">Constraint</span>
+                            <div class="prompt-section-header">
+                                <span class="prompt-label">Constraint</span>
+                                <button class="prompt-reroll-btn" type="button" data-action="constraint">Reroll</button>
+                            </div>
                             <p class="prompt-text constraint">${prompt.constraint.text}</p>
                         </div>
                         <div class="prompt-section">
-                            <span class="prompt-label">Twist</span>
+                            <div class="prompt-section-header">
+                                <span class="prompt-label">Twist</span>
+                                <button class="prompt-reroll-btn" type="button" data-action="twist">Reroll</button>
+                            </div>
                             <p class="prompt-text twist">${prompt.twist}</p>
                         </div>
                     </div>
@@ -1328,6 +1406,13 @@
                         event.preventDefault();
                         selectPrompt(index);
                     }
+                });
+
+                card.querySelectorAll('.prompt-reroll-btn').forEach(button => {
+                    button.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        rerollPromptField(index, button.dataset.action);
+                    });
                 });
 
                 grid.appendChild(card);


### PR DESCRIPTION
### Motivation
- Give users the ability to reroll only the `Constraint` or `Twist` for a generated Concept so they can iterate on variations without replacing the concept itself.  
- Keep the change minimal and consistent with the existing Ideas UI and data pools.  
- Provide an inline control that updates both the prompt card and the Results summary so selections remain consistent.  
- Preserve existing generation rules (tone/local filtering/max cast) and avoid introducing new dependencies.

### Description
- Added UI: small `Reroll` buttons and supporting styles for constraint and twist sections in each prompt card (`ideas.html` CSS/markup).  
- Added JS helpers: `getConstraintPool()`, `getTwistPool()`, `getDifferentItem()` and `rerollPromptField()` to pick a new constraint or twist while avoiding immediate duplicates.  
- Wired per-card listeners so the `Reroll` buttons update the card text and call `updateResultsDisplay()` without changing the card's concept.  
- Appended a CHANGELOG entry in `CHANGELOG_RUNNING.md` documenting the change and manual test checklist.

### Testing
- Automated tests: Not run (environment restriction).  
- Attempted Playwright screenshot run to exercise the roll UI, but the headless browser timed out (failed).  
- Local HTTP server start used during validation (manual) but no automated test suite executed.  
- See appended changelog entry for the manual quick-test checklist to verify behavior and console errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696527a6f3ac832780cddcb6e903e323)