### PR TITLE
Guard ideas prompt generation against missing previous prompt history

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1074,3 +1074,15 @@ Quick test checklist:
 - Open ideas.html; roll prompts, then reroll Constraint and Twist on a card and confirm the text updates in the card.
 - Select a prompt after rerolling and confirm the Current Results section reflects the updated constraint/twist.
 - Open DevTools console on ideas.html; confirm no errors.
+2026-01-12 | 6:51PM EST
+———————————————————————
+Change:
+Fixed prompt generation to handle missing previous prompt history without errors.
+Files touched:
+ideas.html
+Notes:
+Addressed console error that prevented the main roll from returning prompts.
+Quick test checklist:
+- Open ideas.html and click the main roll button to confirm three prompts render.
+- Lock and reroll a prompt field, then confirm the locked items persist.
+- Open DevTools Console on ideas.html and confirm no new errors appear.

--- a/ideas.html
+++ b/ideas.html
@@ -1317,7 +1317,8 @@
             return filterByTone(ideasData.twists, selectedTone, 3);
         }
 
-        function generatePrompts() {
+        function generatePrompts(previousPrompts = []) {
+            const promptHistory = Array.isArray(previousPrompts) ? previousPrompts : [];
             const prompts = [];
             const usedConcepts = new Set();
             const usedConstraints = new Set();
@@ -1328,7 +1329,7 @@
             const twistPool = getTwistPool();
 
             for (let i = 0; i < 3; i++) {
-                const previousPrompt = previousPrompts[i];
+                const previousPrompt = promptHistory[i];
                 const locks = getPromptLocks(previousPrompt);
 
                 // Get unique concept


### PR DESCRIPTION
### Motivation
- The Ideas page main roll was failing with `ReferenceError: previousPrompts is not defined`, preventing prompts from rendering.
- The change ensures prompt generation works when there is no prior roll history (first-time or cleared state). 
- Maintain existing lock/reroll behavior so locked fields persist across rolls when present. 
- Record the change in the running changelog for traceability.

### Description
- Changed the function signature to `generatePrompts(previousPrompts = [])` and added a `promptHistory` fallback to normalize input. 
- Replaced direct uses of `previousPrompts[i]` with `promptHistory[i]` to avoid undefined reference errors. 
- Appended a changelog entry to `CHANGELOG_RUNNING.md` describing the fix and including a manual quick test checklist. 
- Files touched: `ideas.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654287ce448327991b53949ed3a88c)