### PR TITLE
Restore prompt lock defaults to fix 'Roll The Die' crash

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1086,3 +1086,15 @@ Quick test checklist:
 - Open ideas.html and click the main roll button to confirm three prompts render.
 - Lock and reroll a prompt field, then confirm the locked items persist.
 - Open DevTools Console on ideas.html and confirm no new errors appear.
+2026-01-12 | 7:00PM EST
+———————————————————————
+Change:
+Restored prompt lock defaults so rolling the die always generates three prompts.
+Files touched:
+ideas.html, CHANGELOG_RUNNING.md
+Notes:
+Added a safe lock-state helper to prevent prompt generation crashes when no prior history exists.
+Quick test checklist:
+- Open ideas.html and click “Roll The Die”; confirm three prompt cards appear.
+- Click “Roll The Die” again; confirm prompts refresh without console errors.
+- Open DevTools Console on ideas.html; confirm no new errors appear.

--- a/ideas.html
+++ b/ideas.html
@@ -1317,6 +1317,18 @@
             return filterByTone(ideasData.twists, selectedTone, 3);
         }
 
+        function getPromptLocks(previousPrompt) {
+            if (!previousPrompt || !previousPrompt.locks) {
+                return { concept: false, constraint: false, twist: false };
+            }
+
+            return {
+                concept: Boolean(previousPrompt.locks.concept),
+                constraint: Boolean(previousPrompt.locks.constraint),
+                twist: Boolean(previousPrompt.locks.twist)
+            };
+        }
+
         function generatePrompts(previousPrompts = []) {
             const promptHistory = Array.isArray(previousPrompts) ? previousPrompts : [];
             const prompts = [];


### PR DESCRIPTION
### Motivation
- Address a console `ReferenceError` caused by a missing `getPromptLocks` helper which prevented `generatePrompts` from producing prompts when clicking the main roll button.
- Ensure the “Roll The Die” action reliably generates three prompts and retains per-prompt lock/ reroll behavior.
- Keep the change minimal and consistent with the repo’s pure HTML/CSS/JS constraints.

### Description
- Add a safe helper `getPromptLocks(previousPrompt)` that returns a default `{ concept: false, constraint: false, twist: false }` when prior prompt history is absent.
- Use the helper in `generatePrompts` so lock checks no longer throw when `previousPrompt` is undefined.
- Append a changelog entry to `CHANGELOG_RUNNING.md` documenting the fix and a manual quick test checklist.
- Files touched: `ideas.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696544be9f4c8327b34c386d9142f2d8)