### PR TITLE
Guard prompt lock lookup during rolls

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1098,3 +1098,15 @@ Quick test checklist:
 - Open ideas.html and click “Roll The Die”; confirm three prompt cards appear.
 - Click “Roll The Die” again; confirm prompts refresh without console errors.
 - Open DevTools Console on ideas.html; confirm no new errors appear.
+2026-01-12 | 7:08PM EST
+———————————————————————
+Change:
+Guarded prompt lock lookup during prompt generation to prevent roll errors when the lock helper is unavailable.
+Files touched:
+ideas.html, CHANGELOG_RUNNING.md
+Notes:
+Adds a safe fallback so prompt rolls do not throw a ReferenceError.
+Quick test checklist:
+- Open ideas.html and click “Roll The Die”; confirm three prompt cards render.
+- Click “Roll The Die” again; confirm prompts refresh without console errors.
+- Open DevTools Console on ideas.html; confirm no new errors appear.

--- a/ideas.html
+++ b/ideas.html
@@ -1342,7 +1342,9 @@
 
             for (let i = 0; i < 3; i++) {
                 const previousPrompt = promptHistory[i];
-                const locks = getPromptLocks(previousPrompt);
+                const locks = typeof getPromptLocks === 'function'
+                    ? getPromptLocks(previousPrompt)
+                    : { concept: false, constraint: false, twist: false };
 
                 // Get unique concept
                 let concept;


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` thrown when calling `getPromptLocks` during prompt generation, which blocked the main roll action.
- Ensure the prompt roll always returns three prompts even if prior prompt history or the lock helper is unavailable.
- Make a minimal, surgical change that preserves the existing UI and behavior constraints.
- Record the fix in `CHANGELOG_RUNNING.md` per project ops requirements.

### Description
- Guarded the call to `getPromptLocks` inside `generatePrompts` by checking `typeof getPromptLocks === 'function'` and returning a default lock object when the helper is missing.
- Appended a new changelog entry to `CHANGELOG_RUNNING.md` describing the fix and verification steps.
- Modified files: `ideas.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965460c6c4c832781330c0f76c0ea54)