### PR TITLE
Enable horror/comedy toggles and tone-aware prompt sampling in Ideas generator

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1120,3 +1120,13 @@ Quick test checklist:
 - Open resources.html; select Tools → Drone and confirm Betaflight appears in the list.
 - Use the search bar to find Betaflight; confirm it still opens the resource modal.
 - Open DevTools console on Resources page; confirm no errors.
+2026-01-12 | 9:32PM EST
+———————————————————————
+Change: Activate horror/comedy toggles in the Ideas generator with tone-aware prompt pools and uppercase genre detail labels.
+Files touched: ideas.html, CHANGELOG_RUNNING.md
+Notes: Updated prompt generation to sample tone pools with comedy sub-pools and removed glow styling on toggle button modes.
+Quick test checklist:
+- Load ideas.html; toggle Horror/Comedy and confirm the Roll button label and styling change appropriately.
+- Click Roll the Die; confirm prompt cards render and show CREEPY DETAIL or COMEDY BEAT when toggles are active.
+- Click reroll on Constraint/Twist with Comedy active; confirm comedy mechanics/twists appear.
+- Open DevTools console on Ideas page; confirm no errors.

--- a/ideas.html
+++ b/ideas.html
@@ -393,7 +393,6 @@
         .roll-button.horror-mode {
             background: linear-gradient(135deg, #7f1d1d 0%, #450a0a 100%);
             border-color: #EF4444;
-            box-shadow: 0 0 20px rgba(239, 68, 68, 0.3);
         }
 
         .roll-button.horror-mode::before {
@@ -403,7 +402,6 @@
         .roll-button.comedy-mode {
             background: linear-gradient(135deg, #065f46 0%, #064e3b 100%);
             border-color: #22C55E;
-            box-shadow: 0 0 20px rgba(34, 197, 94, 0.3);
         }
 
         .roll-button.comedy-mode::before {
@@ -413,7 +411,6 @@
         .roll-button.both-mode {
             background: linear-gradient(135deg, #7f1d1d 0%, #065f46 100%);
             border-color: #F59E0B;
-            box-shadow: 0 0 20px rgba(245, 158, 11, 0.3);
         }
 
         .roll-button.both-mode::before {
@@ -1394,10 +1391,19 @@
         }
 
         function filterByTone(entries, selectedTone, minimumCount) {
+            return filterByTones(entries, [selectedTone], minimumCount);
+        }
+
+        function filterByTones(entries, selectedTones, minimumCount) {
             const normalizedEntries = entries.map(normalizeIdeaEntryLocal);
-            const filteredEntries = normalizedEntries.filter(entry =>
-                entry.tags.tone.includes(selectedTone) || entry.tags.tone.includes('neutral')
-            );
+            const tones = Array.isArray(selectedTones) ? selectedTones.filter(Boolean) : [];
+            if (!tones.length) {
+                return normalizedEntries;
+            }
+            const filteredEntries = normalizedEntries.filter(entry => {
+                const entryTones = entry.tags.tone || [];
+                return entryTones.includes('neutral') || entryTones.some(tone => tones.includes(tone));
+            });
             if (filteredEntries.length < minimumCount) {
                 return normalizedEntries;
             }
@@ -1448,12 +1454,28 @@
         const localMode = true;
         const maxCast = localMode ? 2 : null;
 
+        function getActiveTones() {
+            const tones = [];
+            const horrorToggle = document.getElementById('toggleHorror');
+            const comedyToggle = document.getElementById('toggleComedy');
+            if (horrorToggle && horrorToggle.checked) {
+                tones.push('horror');
+            }
+            if (comedyToggle && comedyToggle.checked) {
+                tones.push('comedy');
+            }
+            if (!tones.length) {
+                tones.push(selectedTone);
+            }
+            return tones;
+        }
+
         function getConstraintPool() {
-            return filterByTone(ideasData.constraints, selectedTone, 3);
+            return filterByTones(ideasData.constraints, getActiveTones(), 3);
         }
 
         function getTwistPool() {
-            return filterByTone(ideasData.twists, selectedTone, 3);
+            return filterByTones(ideasData.twists, getActiveTones(), 3);
         }
 
         function generatePrompts(previousPrompts = []) {
@@ -1461,7 +1483,7 @@
             const usedConcepts = new Set();
             const usedConstraints = new Set();
             const usedTwists = new Set();
-            let conceptPool = filterByTone(ideasData.concepts, selectedTone, 3);
+            let conceptPool = filterByTones(ideasData.concepts, getActiveTones(), 3);
             conceptPool = filterByMaxCast(conceptPool, maxCast);
             const constraintPool = getConstraintPool();
             const twistPool = getTwistPool();
@@ -1482,24 +1504,24 @@
 
                 // Get unique constraint - may use comedy mechanics if comedy mode active
                 let constraint;
-                if (isComedyMode && ideasData.comedyMechanics && ideasData.comedyMechanics.length > 0 && Math.random() > 0.5) {
-                    constraint = getRandomItem(ideasData.comedyMechanics);
-                } else {
-                    do {
-                        constraint = getRandomItem(constraintPool);
-                    } while (usedConstraints.has(getEntryText(constraint)) && usedConstraints.size < constraintPool.length);
-                }
+                const comedyMechanics = isComedyMode && Array.isArray(ideasData.comedyMechanics) ? ideasData.comedyMechanics : [];
+                const constraintSourcePool = (isComedyMode && Math.random() > 0.5 && comedyMechanics.length)
+                    ? comedyMechanics
+                    : constraintPool;
+                do {
+                    constraint = getRandomItem(constraintSourcePool);
+                } while (usedConstraints.has(getEntryText(constraint)) && usedConstraints.size < constraintSourcePool.length);
                 usedConstraints.add(getEntryText(constraint));
 
                 // Get unique twist - may use comedy twists if comedy mode active
                 let twist;
-                if (isComedyMode && ideasData.comedyTwists && ideasData.comedyTwists.length > 0 && Math.random() > 0.5) {
-                    twist = getRandomItem(ideasData.comedyTwists);
-                } else {
-                    do {
-                        twist = getRandomItem(twistPool);
-                    } while (usedTwists.has(getEntryText(twist)) && usedTwists.size < twistPool.length);
-                }
+                const comedyTwists = isComedyMode && Array.isArray(ideasData.comedyTwists) ? ideasData.comedyTwists : [];
+                const twistSourcePool = (isComedyMode && Math.random() > 0.5 && comedyTwists.length)
+                    ? comedyTwists
+                    : twistPool;
+                do {
+                    twist = getRandomItem(twistSourcePool);
+                } while (usedTwists.has(getEntryText(twist)) && usedTwists.size < twistSourcePool.length);
                 usedTwists.add(getEntryText(twist));
 
                 // Optional flavor elements (rotate, don't force all)
@@ -1555,9 +1577,13 @@
         function rerollPromptField(index, field) {
             const prompt = resultsState.generatedPrompts[index];
             if (!prompt) return;
+            const isComedyMode = comedyToggle && comedyToggle.checked;
 
             if (field === 'constraint') {
-                const nextConstraint = getDifferentItem(getConstraintPool(), getEntryText(prompt.constraint));
+                const constraintPool = getConstraintPool();
+                const comedyMechanics = isComedyMode && Array.isArray(ideasData.comedyMechanics) ? ideasData.comedyMechanics : [];
+                const combinedConstraints = comedyMechanics.length ? [...constraintPool, ...comedyMechanics] : constraintPool;
+                const nextConstraint = getDifferentItem(combinedConstraints, getEntryText(prompt.constraint));
                 if (!nextConstraint) return;
                 prompt.constraint = normalizeIdeaEntryLocal(nextConstraint);
 
@@ -1568,7 +1594,10 @@
             }
 
             if (field === 'twist') {
-                const nextTwist = getDifferentItem(getTwistPool(), prompt.twist);
+                const twistPool = getTwistPool();
+                const comedyTwists = isComedyMode && Array.isArray(ideasData.comedyTwists) ? ideasData.comedyTwists : [];
+                const combinedTwists = comedyTwists.length ? [...twistPool, ...comedyTwists] : twistPool;
+                const nextTwist = getDifferentItem(combinedTwists, prompt.twist);
                 if (!nextTwist) return;
                 prompt.twist = getEntryText(nextTwist);
 
@@ -1611,7 +1640,7 @@
                 if (prompt.creepyDetail) {
                     genreDetailsHTML += `
                         <div class="prompt-section genre-detail creepy">
-                            <span class="prompt-label">Creepy Detail</span>
+                            <span class="prompt-label">CREEPY DETAIL</span>
                             <p class="prompt-text">${prompt.creepyDetail}</p>
                         </div>
                     `;
@@ -1619,7 +1648,7 @@
                 if (prompt.comedyBeat) {
                     genreDetailsHTML += `
                         <div class="prompt-section genre-detail comedy">
-                            <span class="prompt-label">Comedy Beat</span>
+                            <span class="prompt-label">COMEDY BEAT</span>
                             <p class="prompt-text">${prompt.comedyBeat}</p>
                         </div>
                     `;
@@ -1890,7 +1919,7 @@
                     if (prompt.creepyDetail) {
                         genreDetailsResultsHtml += `
                             <div class="results-prompt-section">
-                                <div class="results-item-label" style="color: #EF4444;">Creepy Detail</div>
+                                <div class="results-item-label" style="color: #EF4444;">CREEPY DETAIL</div>
                                 <div class="results-item-text">${prompt.creepyDetail}</div>
                             </div>
                         `;
@@ -1898,7 +1927,7 @@
                     if (prompt.comedyBeat) {
                         genreDetailsResultsHtml += `
                             <div class="results-prompt-section">
-                                <div class="results-item-label" style="color: #22C55E;">Comedy Beat</div>
+                                <div class="results-item-label" style="color: #22C55E;">COMEDY BEAT</div>
                                 <div class="results-item-text">${prompt.comedyBeat}</div>
                             </div>
                         `;


### PR DESCRIPTION
### Motivation
- Complete the Horror/Comedy toggle feature so the generator samples from the new horror/comedy sub-pools and yields genre-appropriate flavor text. 
- Surface small, high-value UI cues on prompt cards (show `CREEPY DETAIL` / `COMEDY BEAT`) to make genre-specific guidance obvious. 
- Make the Roll button reflect active toggles visually while keeping the site’s crisp-line aesthetic (remove glow). 

### Description
- Added a tone-aware pool filter (`filterByTones`) and `getActiveTones()` and switched concept/constraint/twist sampling to use those active tone pools in `generatePrompts()` and `getConstraintPool()`/`getTwistPool()`. 
- Integrated comedy sub-pools by sampling `comedyMechanics` for constraints and `comedyTwists` for twists when Comedy is active, and updated reroll logic to consider combined pools. 
- Updated render logic to use uppercase labels `CREEPY DETAIL` and `COMEDY BEAT` in prompt cards and results, and removed `box-shadow` glow from `.roll-button.horror-mode`, `.roll-button.comedy-mode`, and `.roll-button.both-mode`. 
- Files touched: `ideas.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696567ee67fc8327a8bb304b9a43b6a5)