### PR TITLE
Fix Ideas data parse error blocking roll buttons

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1130,3 +1130,12 @@ Quick test checklist:
 - Click Roll the Die; confirm prompt cards render and show CREEPY DETAIL or COMEDY BEAT when toggles are active.
 - Click reroll on Constraint/Twist with Comedy active; confirm comedy mechanics/twists appear.
 - Open DevTools console on Ideas page; confirm no errors.
+2026-01-12 | 9:40PM EST
+———————————————————————
+Change: Fix Ideas data script parse error so roll buttons can read the objects list.
+Files touched: ideas-data.js, CHANGELOG_RUNNING.md
+Notes: Escaped the HOME quote in the objects list to prevent a JavaScript syntax error.
+Quick test checklist:
+- Open ideas.html; click Roll the Die and confirm prompt cards render with concept/constraint/twist.
+- Use Quick Rollers → Place/Object and confirm each roll shows a result.
+- Open DevTools console on Ideas page; confirm no errors.

--- a/ideas-data.js
+++ b/ideas-data.js
@@ -1044,7 +1044,7 @@ const ideasData = {
         "A used roll of tape with hair stuck to it",
         "A flash drive that's warm to the touch",
         "A return label already addressed to them",
-        "A burner phone with one contact: "HOME"",
+        "A burner phone with one contact: \"HOME\"",
         "A stack of photos where one is missing—cleanly removed",
         "A spare house key that looks newly cut"
     ].map(normalizeIdeaEntry),


### PR DESCRIPTION
### Motivation
- The Ideas page roll buttons and mini-rollers were failing because a JavaScript parse error in the ideas data prevented the script from loading.
- Restoring the data file parse allows the main `Roll the Die` flow and the quick rollers (places/objects/characters/genres) to produce outputs again.
- The repository requires changelog entries for every change, so the fix must be recorded in `CHANGELOG_RUNNING.md`.

### Description
- Escape the embedded quote in `ideas-data.js` so the objects list string parses correctly (`"A burner phone with one contact: \"HOME\""`).
- Append a new entry to `CHANGELOG_RUNNING.md` describing the fix and including the required quick test checklist.
- Files touched: `ideas-data.js`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656a2eaf40832783eec246fb096e38)