### PR TITLE
Restore primary nav on pages and allow YouTube embeds in portfolio

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -1139,3 +1139,13 @@ Quick test checklist:
 - Open ideas.html; click Roll the Die and confirm prompt cards render with concept/constraint/twist.
 - Use Quick Rollers → Place/Object and confirm each roll shows a result.
 - Open DevTools console on Ideas page; confirm no errors.
+2026-01-12 | 9:56PM EST
+———————————————————————
+Change: Restore the primary header navigation on the Events, Resources, Plan, Contact, and Work pages and allow portfolio YouTube embeds via CSP.
+Files touched: events.html, resources.html, plan-your-project.html, contact.html, portfolio.html, CHANGELOG_RUNNING.md
+Notes: Enabled the nav link list on Events and added the primary link row to supporting pages; extended CSP to allow YouTube frames.
+Quick test checklist:
+- Open events.html; confirm the top header shows Resources, Events, Ideas, Plan, Work, Contact.
+- Open resources.html, plan-your-project.html, contact.html, and portfolio.html; confirm the same header links are visible.
+- On portfolio.html click a video placeholder; confirm the YouTube video loads and plays.
+- Open DevTools console on Events and Portfolio pages; confirm no errors.

--- a/contact.html
+++ b/contact.html
@@ -477,6 +477,29 @@
             font-size: 0.7rem;
             color: var(--gray-600);
         }
+
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav-links a {
+            color: var(--white);
+            text-decoration: none;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            transition: opacity 0.3s ease;
+        }
+
+        .nav-links a:hover {
+            opacity: 0.5;
+        }
     </style>
 </head>
 <body>
@@ -485,7 +508,14 @@
         <a href="index.html">
             <img src="images/WhiteBeakerLogo.png" alt="LaB" class="nav-logo">
         </a>
-        <a href="index.html" class="nav-back">← Back</a>
+        <ul class="nav-links">
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="events.html">Events</a></li>
+            <li><a href="ideas.html">Ideas</a></li>
+            <li><a href="plan-your-project.html">Plan</a></li>
+            <li><a href="portfolio.html">Work</a></li>
+            <li><a href="contact.html">Contact</a></li>
+        </ul>
     </nav>
 
     <!-- Contact -->

--- a/events.html
+++ b/events.html
@@ -84,7 +84,12 @@
         }
 
         .nav-links {
-            display: none; /* Hide the right-side navigation */
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            list-style: none;
+            margin: 0;
+            padding: 0;
         }
 
         .nav-links a {
@@ -1205,7 +1210,7 @@
             <li><a href="ideas.html">Ideas</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Work</a></li>
-            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="contact.html">Contact</a></li>
         </ul>
     </nav>
 

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -95,6 +95,29 @@
         .nav-back:hover {
             opacity: 0.5;
         }
+
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav-links a {
+            color: var(--white);
+            text-decoration: none;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            transition: opacity 0.3s ease;
+        }
+
+        .nav-links a:hover {
+            opacity: 0.5;
+        }
         
         /* Main Layout */
         .main {
@@ -946,7 +969,14 @@
         <a href="index.html">
             <img src="images/WhiteBeakerLogo.png" alt="LaB" class="nav-logo">
         </a>
-        <a href="index.html" class="nav-back">← Back</a>
+        <ul class="nav-links">
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="events.html">Events</a></li>
+            <li><a href="ideas.html">Ideas</a></li>
+            <li><a href="plan-your-project.html">Plan</a></li>
+            <li><a href="portfolio.html">Work</a></li>
+            <li><a href="contact.html">Contact</a></li>
+        </ul>
     </nav>
     
     <main class="main">

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
     <title>Work | LaB Media</title>
     <link rel="canonical" href="https://labmedia.work/portfolio.html">
 
@@ -98,6 +98,29 @@
         }
         
         .nav-back:hover {
+            opacity: 0.5;
+        }
+
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav-links a {
+            color: var(--white);
+            text-decoration: none;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            transition: opacity 0.3s ease;
+        }
+
+        .nav-links a:hover {
             opacity: 0.5;
         }
         
@@ -1042,7 +1065,14 @@
         <a href="index.html">
             <img src="images/WhiteBeakerLogo.png" alt="LaB Media" class="nav-logo">
         </a>
-        <a href="index.html" class="nav-back">← Back</a>
+        <ul class="nav-links">
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="events.html">Events</a></li>
+            <li><a href="ideas.html">Ideas</a></li>
+            <li><a href="plan-your-project.html">Plan</a></li>
+            <li><a href="portfolio.html">Work</a></li>
+            <li><a href="contact.html">Contact</a></li>
+        </ul>
     </nav>
     
     <!-- Project Counter -->

--- a/resources.html
+++ b/resources.html
@@ -93,6 +93,27 @@
         
         .nav-back:hover { opacity: 0.5; }
 
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav-links a {
+            color: var(--white);
+            text-decoration: none;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            transition: opacity 0.3s ease;
+        }
+
+        .nav-links a:hover { opacity: 0.5; }
+
         /* ============================================
            HERO SECTION
         ============================================ */
@@ -1843,7 +1864,14 @@
         <a href="index.html">
             <img src="images/WhiteBeakerLogo.png" alt="LaB" class="nav-logo">
         </a>
-        <a href="index.html" class="nav-back">← Back</a>
+        <ul class="nav-links">
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="events.html">Events</a></li>
+            <li><a href="ideas.html">Ideas</a></li>
+            <li><a href="plan-your-project.html">Plan</a></li>
+            <li><a href="portfolio.html">Work</a></li>
+            <li><a href="contact.html">Contact</a></li>
+        </ul>
     </nav>
     
     <div class="container proto-grid">


### PR DESCRIPTION
### Motivation
- Ensure the site header shows the primary link row (RESOURCES / EVENTS / IDEAS / PLAN / WORK / CONTACT) consistently across pages for a unified navigation experience.
- Fix portfolio video placeholders that were not loading because embedded YouTube frames were blocked by the Content-Security-Policy.
- Keep changes minimal and surgical by adding the shared nav markup/styles rather than reworking global layout or introducing dependencies.
- Record the change in the running changelog as required by project policy.

### Description
- Restored the primary nav link row in `events.html`, `resources.html`, `plan-your-project.html`, `contact.html`, and `portfolio.html`, and updated the Events page contact link to `contact.html`.
- Added `.nav-links` CSS and markup to the affected pages so the top header displays the link row with consistent styling.
- Updated the CSP in `portfolio.html` by adding `frame-src https://www.youtube.com https://www.youtube-nocookie.com` to allow the existing `loadVideo` code to inject YouTube iframes.
- Appended a new entry to `CHANGELOG_RUNNING.md` describing the change and quick test checklist.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656d637cd88327b3973e9e33f49c44)