### PR TITLE
Reorder homepage sections for credibility-first flow

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 6:10AM EST
+———————————————————————
+Change: Reordered homepage sections to lead with Work before the Story Generator CTA, Events Preview, and Resources.
+Files touched: index.html
+Notes: Homepage flow now matches the "Credibility Then Community" layout request.
+Quick test checklist:
+1. Open index.html and verify the Work section appears directly after the Hero.
+2. Scroll down to confirm Story Generator CTA follows Work.
+3. Confirm Events Preview appears after the Story Generator CTA.
+4. Confirm Resources section appears after Events Preview.
+5. Check DevTools console for any errors.
+
 2026-01-13 | 1:05AM EST
 ———————————————————————
 Change: FINAL FIX - Portfolio navigation dots now properly positioned on far right edge (not center)

--- a/index.html
+++ b/index.html
@@ -1665,57 +1665,6 @@
         </div>
     </section>
 
-    <!-- Story Generator CTA -->
-    <section class="story-generator-cta proto-grid">
-        <div class="story-cta-inner">
-            <div class="story-cta-label proto-text-mono">Writer's Block?</div>
-            <h2 class="story-cta-title">Roll the Dice</h2>
-            <p class="story-cta-desc">Instant film prompts. Genre, character, setting, twist. Horror & comedy modes included.</p>
-            <a href="ideas.html" class="story-cta-btn proto-btn">
-                <span>Try Story Generator</span>
-                <span class="story-cta-arrow">→</span>
-            </a>
-        </div>
-    </section>
-
-    <!-- Events Preview Section -->
-    <section class="events-preview">
-        <div class="events-preview-inner">
-            <div class="section-header">
-                <span class="section-label proto-text-mono">Upcoming</span>
-                <div class="section-line"></div>
-                <span class="section-count proto-text-mono" id="eventsCount">00</span>
-            </div>
-
-            <div class="events-preview-grid" id="eventsPreviewGrid">
-                <!-- Events will be dynamically inserted here -->
-            </div>
-
-            <div class="view-all">
-                <a href="events.html">View Full Calendar</a>
-            </div>
-        </div>
-    </section>
-
-    <!-- Resources Section -->
-    <section class="resources-section proto-grid">
-        <div class="section-header">
-            <span class="section-label proto-text-mono">For Reference</span>
-            <div class="section-line"></div>
-            <span class="section-count proto-text-mono">04</span>
-        </div>
-        <div class="resources-inner">
-            <div class="resources-text">
-                <h3 class="resources-title proto-text-mono">Production Toolkit</h3>
-                <p class="resources-desc">Music licensing, AI tools, gear rentals, and everything else we use to make things.</p>
-            </div>
-            <a href="resources.html" class="resources-link proto-btn">
-                <span>Browse Resources</span>
-                <span class="resources-arrow">→</span>
-            </a>
-        </div>
-    </section>
-
     <!-- Work -->
     <section class="work" id="work">
         <div class="section-header">
@@ -1790,6 +1739,57 @@
 
         <div class="view-all">
             <a href="portfolio.html">View All</a>
+        </div>
+    </section>
+
+    <!-- Story Generator CTA -->
+    <section class="story-generator-cta proto-grid">
+        <div class="story-cta-inner">
+            <div class="story-cta-label proto-text-mono">Writer's Block?</div>
+            <h2 class="story-cta-title">Roll the Dice</h2>
+            <p class="story-cta-desc">Instant film prompts. Genre, character, setting, twist. Horror & comedy modes included.</p>
+            <a href="ideas.html" class="story-cta-btn proto-btn">
+                <span>Try Story Generator</span>
+                <span class="story-cta-arrow">→</span>
+            </a>
+        </div>
+    </section>
+
+    <!-- Events Preview Section -->
+    <section class="events-preview">
+        <div class="events-preview-inner">
+            <div class="section-header">
+                <span class="section-label proto-text-mono">Upcoming</span>
+                <div class="section-line"></div>
+                <span class="section-count proto-text-mono" id="eventsCount">00</span>
+            </div>
+
+            <div class="events-preview-grid" id="eventsPreviewGrid">
+                <!-- Events will be dynamically inserted here -->
+            </div>
+
+            <div class="view-all">
+                <a href="events.html">View Full Calendar</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Resources Section -->
+    <section class="resources-section proto-grid">
+        <div class="section-header">
+            <span class="section-label proto-text-mono">For Reference</span>
+            <div class="section-line"></div>
+            <span class="section-count proto-text-mono">04</span>
+        </div>
+        <div class="resources-inner">
+            <div class="resources-text">
+                <h3 class="resources-title proto-text-mono">Production Toolkit</h3>
+                <p class="resources-desc">Music licensing, AI tools, gear rentals, and everything else we use to make things.</p>
+            </div>
+            <a href="resources.html" class="resources-link proto-btn">
+                <span>Browse Resources</span>
+                <span class="resources-arrow">→</span>
+            </a>
         </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Reorganize the homepage to follow a “Credibility Then Community” flow so quality work surfaces first, then community engagement prompts. 
- Surface the `Work` section immediately after the `Hero` to emphasize portfolio credibility before calls-to-action. 
- Keep interactive and discovery sections (`Story Generator CTA`, `Events Preview`, `Resources`) grouped after the portfolio to invite engagement. 

### Description
- Moved the entire `Work` HTML block so the `Work` section now appears directly after the `Hero` in `index.html`.
- Shifted the `Story Generator CTA`, `Events Preview`, and `Resources` sections to follow the `Work` section accordingly in `index.html`.
- Added a timestamped entry to `CHANGELOG_RUNNING.md` documenting the reorder and a quick verification checklist.

### Testing
- No automated tests were run for this change (static content reorder only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e039f7688327960a6d8a159221b1)