### PR TITLE
Add “LaB Talk (Beta)” footer link and homepage microcopy

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 2:47AM EST
+———————————————————————
+Change: Added LaB Talk (Beta) footer link across site pages and a muted homepage footer note describing the tool.
+Files touched: index.html, resources.html, portfolio.html, plan-your-project.html, past-events.html, events.html, contact.html, ideas.html
+Notes: Footer-only link opens the hosted AI Studio app in a new tab; microcopy appears only on the homepage footer.
+Quick test checklist:
+1. Open index.html and confirm the footer shows the LaB Talk (Beta) link and the muted descriptive line, with the top nav unchanged.
+2. Open resources.html, portfolio.html, plan-your-project.html, past-events.html, events.html, contact.html, and ideas.html to confirm the footer includes the LaB Talk (Beta) link.
+3. Click the LaB Talk (Beta) link on any page and verify it opens the AI Studio app in a new tab.
+4. Check mobile layout in the browser responsive mode to ensure the footer spacing remains intact.
+5. Check DevTools console for errors on index.html and a secondary page (ex: resources.html).
+
 2026-01-13 | 7:11AM EST
 ———————————————————————
 Change: Removed duplicate top navigation styling on the portfolio page and cleaned up video framing with varied video sizes.

--- a/contact.html
+++ b/contact.html
@@ -648,6 +648,7 @@
             <a href="resources.html">Resources</a>
             <a href="events.html">Events</a>
             <a href="ideas.html">Story Generator</a>
+            <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
         </nav>
         <a href="plan-your-project.html" class="footer-cta">Start a Project</a>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>

--- a/events.html
+++ b/events.html
@@ -2249,6 +2249,7 @@ END:VCALENDAR`;
             <a href="portfolio.html">Work</a>
             <a href="resources.html">Resources</a>
             <a href="ideas.html">Story Generator</a>
+            <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
         </nav>
         <a href="plan-your-project.html" class="footer-cta">Start a Project</a>

--- a/ideas.html
+++ b/ideas.html
@@ -1365,6 +1365,7 @@
                 <a href="index.html">Home</a>
                 <a href="portfolio.html">Work</a>
                 <a href="resources.html">Resources</a>
+                <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
                 <a href="contact.html">Contact</a>
             </div>
             <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>

--- a/index.html
+++ b/index.html
@@ -1586,6 +1586,14 @@
             letter-spacing: 1px;
         }
 
+        .footer-note {
+            display: block;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.6rem;
+            color: var(--gray-600);
+            letter-spacing: 0.6px;
+        }
+
         .footer-link {
             font-family: 'Space Mono', monospace;
             font-size: 0.6rem;
@@ -2182,9 +2190,13 @@
 
     <!-- Footer -->
     <footer>
-        <div class="footer-copy">© 2025 LaB Media</div>
+        <div class="footer-copy">
+            © 2025 LaB Media
+            <span class="footer-note">Turn project notes into a quick narrated mini-podcast — table-read energy for your ideas, in audio form.</span>
+        </div>
         <a href="#" class="footer-link" id="voiceAgentFooterLink">Voice Agent</a>
         <a href="https://youtube.com/@BobtastiCFPV" class="footer-link" target="_blank" rel="noopener">FPV</a>
+        <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" class="footer-link" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
         <a href="plan-your-project.html" class="footer-cta">
             <span class="footer-cta-text">Start Project</span>
             <span class="footer-cta-arrow">→</span>

--- a/past-events.html
+++ b/past-events.html
@@ -357,6 +357,7 @@
             <a href="portfolio.html">Work</a>
             <a href="resources.html">Resources</a>
             <a href="ideas.html">Story Generator</a>
+            <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
         </nav>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -1604,6 +1604,7 @@ Submitted: ${new Date().toLocaleString()}
             <a href="resources.html">Resources</a>
             <a href="events.html">Events</a>
             <a href="ideas.html">Story Generator</a>
+            <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
         </nav>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>

--- a/portfolio.html
+++ b/portfolio.html
@@ -1593,6 +1593,7 @@
             <a href="resources.html">Resources</a>
             <a href="events.html">Events</a>
             <a href="ideas.html">Story Generator</a>
+            <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
         </nav>
         <a href="plan-your-project.html" class="footer-cta">Start a Project</a>

--- a/resources.html
+++ b/resources.html
@@ -2008,6 +2008,7 @@
             <a href="portfolio.html">Work</a>
             <a href="events.html">Events</a>
             <a href="ideas.html">Story Generator</a>
+            <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
         </nav>
         <a href="plan-your-project.html" class="footer-cta">Start a Project</a>


### PR DESCRIPTION
### Motivation
- Surface the live LaB Talk beta (hosted AI Studio app) in the site footer without changing top navigation or layout.  
- Keep the link subtle and typographically consistent with existing footer links (`Space Mono`, small caps).  
- Provide a brief, muted homepage description so visitors understand the tool at a glance.  
- Follow repo rules by keeping the change surgical and updating the running changelog before committing.  

### Description
- Added a footer link `LaB Talk (Beta)` pointing to `https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true` with `target="_blank" rel="noopener noreferrer"` on the following pages: `index.html`, `resources.html`, `portfolio.html`, `plan-your-project.html`, `past-events.html`, `events.html`, `contact.html`, and `ideas.html`.  
- Added a muted homepage footer line and accompanying `.footer-note` CSS in `index.html` with the exact microcopy: "Turn project notes into a quick narrated mini-podcast — table-read energy for your ideas, in audio form."  
- Updated `CHANGELOG_RUNNING.md` with a new entry listing the change, files touched, notes, and a quick test checklist per project rules.  
- No top-nav changes, no CSP or dependency changes, and mobile/footer spacing/layout were not altered.  

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f8153e148327830ca59cce35c239)