### PR TITLE
Remove homepage hero headline and description

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 7:54AM EST
+———————————————————————
+Change: Removed the hero headline and description text from the homepage hero block.
+Files touched: index.html
+Notes: Kept the hero pills intact while clearing the hero copy per request.
+Quick test checklist:
+1. Open index.html and confirm the hero headline/description text is gone.
+2. Verify the hero pills still render in the hero block.
+3. Open DevTools console and confirm no errors on index.html.
+
 2026-01-13 | 2:47AM EST
 ———————————————————————
 Change: Added LaB Talk (Beta) footer link across site pages and a muted homepage footer note describing the tool.

--- a/index.html
+++ b/index.html
@@ -1990,11 +1990,6 @@
         <img src="images/TheLaB.png" alt="The LaB" class="hero-logo" loading="lazy">
 
         <div class="hero-content">
-            <h1 class="hero-heading">Metro Detroit filmmaker-first studio</h1>
-            <p class="hero-description">
-                Local tools, events, and resources built to move projects from idea to shootable plan.
-                If you’re making films in Metro Detroit, this is your home base.
-            </p>
             <div class="hero-pills">
                 <span class="hero-pill">Local Focus</span>
                 <span class="hero-pill">Story Generator</span>


### PR DESCRIPTION
### Motivation
- The homepage hero contained Metro Detroit–focused headline and description text that needed to be removed per request.
- The change should be surgical and preserve the existing hero layout, pills, and site aesthetic.
- The project requires every change to be recorded in the running changelog before committing.

### Description
- Removed the hero `<h1>` headline and `<p>` description from `index.html` while keeping the hero pills and tagline intact.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the removal and a short quick-test checklist.
- The updated files are `index.html` and `CHANGELOG_RUNNING.md` and the changes were committed.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fa0fc1cc8327bc2bad223f5a4a6e)