### PR TITLE
Scope header nav styles and fix duplicated nav on Plan & Contact pages

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 2:09PM EST
+———————————————————————
+Change: Scoped header nav styles on Plan and Contact pages to prevent the footer nav from rendering as a fixed header.
+Files touched: plan-your-project.html, contact.html
+Notes: Footer navs now keep their footer styling while the header nav remains fixed.
+Quick test checklist:
+1. Open plan-your-project.html and confirm only one top nav row appears and the footer nav stays at the bottom.
+2. Open contact.html and confirm only one top nav row appears and the footer nav stays at the bottom.
+3. Open DevTools console on both pages and confirm no errors.
+
 2026-01-13 | 7:54AM EST
 ———————————————————————
 Change: Removed the hero headline and description text from the homepage hero block.

--- a/contact.html
+++ b/contact.html
@@ -64,7 +64,7 @@
         }
 
         /* Navigation */
-        nav {
+        .site-nav {
             position: fixed;
             top: 0;
             left: 0;
@@ -77,18 +77,18 @@
             mix-blend-mode: difference;
         }
 
-        .nav-logo {
+        .site-nav .nav-logo {
             height: 22px;
             width: auto;
             filter: brightness(0) invert(1);
             transition: opacity 0.3s ease;
         }
 
-        .nav-logo:hover {
+        .site-nav .nav-logo:hover {
             opacity: 0.6;
         }
 
-        .nav-back {
+        .site-nav .nav-back {
             font-family: 'Space Mono', monospace;
             font-size: 0.7rem;
             color: var(--white);
@@ -97,7 +97,7 @@
             transition: opacity 0.3s ease;
         }
 
-        .nav-back:hover {
+        .site-nav .nav-back:hover {
             opacity: 0.5;
         }
 
@@ -406,7 +406,7 @@
         }
 
         @media (max-width: 640px) {
-            nav {
+            .site-nav {
                 padding: 1.5rem;
             }
 
@@ -478,7 +478,7 @@
             color: var(--gray-600);
         }
 
-        .nav-links {
+        .site-nav .nav-links {
             display: flex;
             align-items: center;
             gap: 1.5rem;
@@ -487,7 +487,7 @@
             padding: 0;
         }
 
-        .nav-links a {
+        .site-nav .nav-links a {
             color: var(--white);
             text-decoration: none;
             font-family: 'Space Mono', monospace;
@@ -497,14 +497,14 @@
             transition: opacity 0.3s ease;
         }
 
-        .nav-links a:hover {
+        .site-nav .nav-links a:hover {
             opacity: 0.5;
         }
     </style>
 </head>
 <body>
     <!-- Navigation -->
-    <nav>
+    <nav class="site-nav">
         <a href="index.html">
             <img src="images/WhiteBeakerLogo.png" alt="LaB" class="nav-logo">
         </a>

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -64,7 +64,7 @@
         }
         
         /* Navigation */
-        nav {
+        .site-nav {
             position: fixed;
             top: 0;
             left: 0;
@@ -77,13 +77,13 @@
             mix-blend-mode: difference;
         }
         
-        .nav-logo {
+        .site-nav .nav-logo {
             height: 22px;
             width: auto;
             filter: brightness(0) invert(1);
         }
         
-        .nav-back {
+        .site-nav .nav-back {
             font-family: 'Space Mono', monospace;
             font-size: 0.7rem;
             color: var(--white);
@@ -92,11 +92,11 @@
             transition: opacity 0.3s ease;
         }
         
-        .nav-back:hover {
+        .site-nav .nav-back:hover {
             opacity: 0.5;
         }
 
-        .nav-links {
+        .site-nav .nav-links {
             display: flex;
             align-items: center;
             gap: 1.5rem;
@@ -105,7 +105,7 @@
             padding: 0;
         }
 
-        .nav-links a {
+        .site-nav .nav-links a {
             color: var(--white);
             text-decoration: none;
             font-family: 'Space Mono', monospace;
@@ -115,7 +115,7 @@
             transition: opacity 0.3s ease;
         }
 
-        .nav-links a:hover {
+        .site-nav .nav-links a:hover {
             opacity: 0.5;
         }
         
@@ -999,7 +999,7 @@
     </div>
     
     <!-- Navigation -->
-    <nav>
+    <nav class="site-nav">
         <a href="index.html">
             <img src="images/WhiteBeakerLogo.png" alt="LaB" class="nav-logo">
         </a>


### PR DESCRIPTION
### Motivation
- The footer navigation was accidentally inheriting global `nav` styles and rendering as a fixed header, producing a duplicated top nav on some pages.  
- The change scopes header navigation styling so the primary header remains fixed while the footer nav retains footer-specific styling.

### Description
- Replace top-level `nav` CSS rules with scoped `.site-nav` selectors in `plan-your-project.html` and `contact.html`.  
- Add `class="site-nav"` to the header `<nav>` element in both `plan-your-project.html` and `contact.html`.  
- Update related selectors such as `.site-nav .nav-logo`, `.site-nav .nav-links`, and the mobile `@media` rule in `contact.html` so footer styles are not affected.  
- Record the change in `CHANGELOG_RUNNING.md` with a short test checklist.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664dc76b54832792558f3d9aaa8b9b)