### PR TITLE
Relabel Tools → Gear, move Dodford to Editing, trim AI list, fix footer nav, update changelog

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 4:02PM EST
+———————————————————————
+Change: Renamed the Tools subfilter to Gear, moved Dodford into editing references, trimmed the AI list, and fixed footer nav markup so it no longer mirrors the fixed header.
+Files touched: resources.html, resources-data.js, CHANGELOG_RUNNING.md
+Notes: Footer nav now uses non-nav markup to avoid global fixed nav styling on resources.html.
+Quick test checklist:
+1. Open resources.html and confirm the Tools subfilter shows Gear (not Software) and the footer nav stays at the bottom without duplicating the header.
+2. Filter References > Editing and confirm Dodford appears there.
+3. Open Tools > AI and confirm Grok, Gemini, and Perplexity no longer appear.
+4. Open DevTools console on resources.html and confirm no errors.
+
 2026-01-13 | 2:09PM EST
 ———————————————————————
 Change: Scoped header nav styles on Plan and Contact pages to prevent the footer nav from rendering as a fixed header.

--- a/resources-data.js
+++ b/resources-data.js
@@ -378,7 +378,7 @@ const resources = [
     {
         name: 'Dodford',
         category: 'references',
-        refType: 'filming',
+        refType: 'editing',
         desc: 'Visual storytelling experiments with a creator-first, process-forward approach.',
         fullDesc: 'A channel built around creative experimentation—useful for seeing how simple ideas evolve into polished visual narratives.',
         url: 'https://www.youtube.com/@DodfordYT',
@@ -1168,21 +1168,6 @@ const resources = [
         features: ['Long Context', 'Coding Help', 'Writing Support', 'Browser-Based']
     },
     {
-        name: 'Grok',
-        category: 'ai',
-        aiType: 'chat',
-        desc: 'xAI\'s chatbot with real-time X platform access and free limited usage.',
-        fullDesc: 'Grok is xAI\'s AI chatbot featuring real-time access to X (Twitter) for current events and trending topics. Available in 29 languages with Fast and Expert modes. Free tier offers limited access (~10 requests every 2 hours), while paid plans unlock Grok 4 and higher usage limits. API access available for developers.',
-        url: 'https://grok.com',
-        paid: true,
-        pricing: [
-            { plan: 'Free', price: '$0 (limited, via X)' },
-            { plan: 'SuperGrok', price: '$30/mo' },
-            { plan: 'X Premium+', price: '$40/mo' }
-        ],
-        features: ['Real-Time X Access', 'Current Events', 'Image Generation', 'Voice Function', 'API Available']
-    },
-    {
         name: 'Chat.com',
         category: 'ai',
         aiType: 'chat',
@@ -1279,34 +1264,6 @@ const resources = [
         url: 'https://sora.chatgpt.com',
         paid: false,
         features: ['Text-to-Video', 'Cinematic Motion', 'Camera Control', 'Previsualization']
-    },
-    {
-        name: 'Gemini',
-        category: 'ai',
-        aiType: 'chat',
-        desc: 'Google’s multimodal assistant for research, outlining, and coding.',
-        fullDesc: 'Gemini handles chat, code, and image understanding in one workspace—good for script coverage, outline drafts, research pulls, and quick code snippets with Google account sign-in.',
-        url: 'https://gemini.google.com',
-        paid: true,
-        pricing: [
-            { plan: 'Free', price: '$0' },
-            { plan: 'Advanced', price: '$19.99/mo' }
-        ],
-        features: ['Multimodal', 'Research', 'Code Help', 'Outline Drafts']
-    },
-    {
-        name: 'Perplexity',
-        category: 'ai',
-        aiType: 'chat',
-        desc: 'Answer-focused AI with citations and quick reading mode.',
-        fullDesc: 'Perplexity blends web search with AI summaries, returning citations by default—handy for fast fact checks, source gathering, and concise briefs before deeper dives.',
-        url: 'https://www.perplexity.ai',
-        paid: true,
-        pricing: [
-            { plan: 'Free', price: '$0' },
-            { plan: 'Pro', price: '$20/mo' }
-        ],
-        features: ['Cited Answers', 'Web Search', 'Summaries', 'Reading Mode']
     },
     {
         name: 'Krotos Studio (AI)',

--- a/resources.html
+++ b/resources.html
@@ -1938,7 +1938,7 @@
             <div class="subfilter-buttons">
                 <button class="subfilter-btn active" data-tools="ai">AI</button>
                 <button class="subfilter-btn" data-tools="drone">Drone</button>
-                <button class="subfilter-btn" data-tools="gear">Software</button>
+                <button class="subfilter-btn" data-tools="gear">Gear</button>
                 <button class="subfilter-btn" data-tools="casting">Casting</button>
                 <button class="subfilter-btn active" data-tools="all-tools">All</button>
             </div>
@@ -2003,14 +2003,14 @@
     </div>
     
     <footer>
-        <nav class="footer-nav">
+        <div class="footer-nav" aria-label="Footer navigation">
             <a href="index.html">Home</a>
             <a href="portfolio.html">Work</a>
             <a href="events.html">Events</a>
             <a href="ideas.html">Story Generator</a>
             <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
-        </nav>
+        </div>
         <a href="plan-your-project.html" class="footer-cta">Start a Project</a>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>
     </footer>


### PR DESCRIPTION
### Motivation
- Clarify the Tools subfilter label to better match the items it surfaces (change `Software` → `Gear`).
- Prevent the footer navigation from being styled as a fixed header on `resources.html` by adjusting markup to avoid global header styling leaks.
- Reorganize resource data: move `Dodford` into the Editing references bucket and remove a few AI entries to keep the AI list curated and focused.

### Description
- Updated the Tools subfilter label in `resources.html` from `Software` to `Gear` so subfilter text reads `Gear` under Tools.
- Replaced the footer `<nav class="footer-nav">` wrapper with a non-nav container (`<div class="footer-nav" aria-label="Footer navigation">`) in `resources.html` to avoid the header being duplicated by global fixed-nav CSS.
- Edited `resources-data.js` to change `Dodford`'s `refType` to `editing` and removed the `Grok`, `Gemini`, and `Perplexity` entries from the AI list.
- Appended an entry to `CHANGELOG_RUNNING.md` documenting the change and listing touched files: `resources.html`, `resources-data.js`, and `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).
- Changelog verification: confirmed a new entry was appended to `CHANGELOG_RUNNING.md` describing the changes and listing files touched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69666c42209c83278ffa17a196b1cbe1)