### PR TITLE
Add lightweight onboarding hints and local mission copy to key pages

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 1:10PM EST
+———————————————————————
+Change: Added lightweight guidance copy to the homepage, Ideas, Resources, and Events pages to clarify primary flows and local focus.
+Files touched: index.html, ideas.html, resources.html, events.html, CHANGELOG_RUNNING.md
+Notes: Microcopy hints reinforce first-time user flow without changing layout structure.
+Quick test checklist:
+1. Open index.html and confirm the new hero mission line appears under the pills.
+2. Open ideas.html and confirm the start-here hint appears below the roll buttons.
+3. Open resources.html and confirm the filter hint appears between search and category filters.
+4. Open events.html and confirm the local focus line appears under the hero description.
+5. Open DevTools console on each touched page and confirm no errors.
+
 2026-01-13 | 4:02PM EST
 ———————————————————————
 Change: Renamed the Tools subfilter to Gear, moved Dodford into editing references, trimmed the AI list, and fixed footer nav markup so it no longer mirrors the fixed header.

--- a/events.html
+++ b/events.html
@@ -130,6 +130,15 @@
             font-size: 0.95rem;
         }
 
+        .hero-local {
+            margin: -0.75rem 0 1.5rem;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.65rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: var(--gray-600);
+        }
+
         /* Event Type Legend */
         .event-legend {
             display: flex;
@@ -1238,6 +1247,7 @@
         <section class="hero">
             <h1>Events</h1>
             <p>Screenings, meetups, and deadlines keeping the Detroit creative community connected.</p>
+            <p class="hero-local">Metro Detroit only — roughly 50 miles from Shelby Township.</p>
 
             <div class="view-toggle">
                 <button class="view-btn active" data-view="calendar">📅 Calendar</button>

--- a/ideas.html
+++ b/ideas.html
@@ -211,6 +211,15 @@
             gap: 1rem;
         }
 
+        .flow-hint {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.65rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: var(--gray-600);
+            opacity: 0.8;
+        }
+
         .roll-button {
             position: relative;
             display: inline-flex;
@@ -1216,6 +1225,7 @@
                     <span class="roll-all-icon">&#x2726;</span>
                     <span>Roll All (One-Time)</span>
                 </button>
+                <p class="flow-hint">Start here: roll, pick a prompt, build the short.</p>
             </div>
 
             <div class="prompts-container" id="promptsContainer">

--- a/index.html
+++ b/index.html
@@ -405,6 +405,14 @@
             color: var(--gray-400);
             background: rgba(255, 255, 255, 0.03);
         }
+
+        .hero-mission {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.65rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: var(--gray-600);
+        }
         
         .scroll-indicator {
             position: absolute;
@@ -1995,6 +2003,7 @@
                 <span class="hero-pill">Story Generator</span>
                 <span class="hero-pill">Events + Resources</span>
             </div>
+            <div class="hero-mission">A local hub for Detroit filmmakers to find tools, ideas, and events.</div>
         </div>
 
         <div class="hero-tagline proto-text-mono">A Creative Studio</div>

--- a/resources.html
+++ b/resources.html
@@ -196,6 +196,16 @@
             background: rgba(255, 255, 255, 0.02);
         }
 
+        .filter-hint {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.65rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: var(--gray-600);
+            margin-bottom: 0.75rem;
+            opacity: 0.85;
+        }
+
         /* Label flicker animation */
         @keyframes labelFlicker {
             0%, 100% {
@@ -1895,6 +1905,8 @@
         <div class="search-row">
             <input type="text" class="search-input proto-card" id="searchInput" placeholder="Search resources..." autocomplete="off">
         </div>
+
+        <div class="filter-hint">Start with a category, then refine with subfilters.</div>
         
         <!-- Main Category Filter Row -->
         <div class="filter-row">


### PR DESCRIPTION
### Motivation
- Clarify first-time user flows by adding concise guidance prompts near core actions. 
- Surface the site’s local focus to set expectations for event listings. 
- Maintain the existing aesthetic by reusing the monospace, uppercase microcopy style. 

### Description
- Added small UI hint styles and classes (`.hero-mission`, `.flow-hint`, `.filter-hint`, `.hero-local`) to the CSS in `index.html`, `ideas.html`, `resources.html`, and `events.html`. 
- Inserted a hero mission line under the hero pills in `index.html` (`A local hub for Detroit filmmakers to find tools, ideas, and events.`). 
- Added a “Start here” flow hint below the roll buttons in `ideas.html` and a filter guidance line between the search input and category filters in `resources.html`. 
- Added a Metro Detroit locality note to the `events.html` hero and recorded the change in `CHANGELOG_RUNNING.md`.

### Testing
- No automated tests were run for these static HTML/CSS content updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966858cb45883278898505ca59f2ddb)