### PR TITLE
Update homepage: rename Work→Portfolio, 'Selected Work'→'Our Stuff', move Story Generator, remove Voice Agent

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 6:18PM EST
+———————————————————————
+Change: Updated the homepage section order, portfolio labeling, and removed the voice agent entry points.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes: Story Generator now sits between Events and the Production Toolkit; portfolio copy is simplified.
+Quick test checklist:
+1. Open index.html and confirm the portfolio section label reads “Our Stuff” and the intro sentence is removed.
+2. Scroll past Events and confirm the Story Generator CTA appears before the Production Toolkit block.
+3. Confirm the Voice Agent button/link/modal are no longer present on the homepage.
+4. Open DevTools console on index.html and confirm no errors.
+
 2026-01-13 | 1:10PM EST
 ———————————————————————
 Change: Added lightweight guidance copy to the homepage, Ideas, Resources, and Events pages to clarify primary flows and local focus.

--- a/index.html
+++ b/index.html
@@ -1659,92 +1659,6 @@
         }
 
         /* ============================================
-           VOICE AGENT MODAL
-        ============================================ */
-        .voice-modal-backdrop {
-            position: fixed;
-            inset: 0;
-            background: rgba(0, 0, 0, 0.65);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1.5rem;
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
-            z-index: 1200;
-        }
-
-        .voice-modal-backdrop.is-open {
-            opacity: 1;
-            visibility: visible;
-            pointer-events: auto;
-        }
-
-        .voice-modal {
-            width: min(720px, 100%);
-            max-height: 70vh;
-            background: #050505;
-            border: 1px solid var(--gray-800);
-            border-radius: 12px;
-            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
-            display: flex;
-            flex-direction: column;
-            overflow: hidden;
-            opacity: 0;
-            transform-origin: center;
-            outline: none;
-        }
-
-        .voice-modal-header {
-            padding: 1rem 1.25rem;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 1rem;
-            border-bottom: 1px solid var(--gray-800);
-        }
-
-        .voice-modal-kicker {
-            font-family: 'Space Mono', monospace;
-            font-size: 0.6rem;
-            letter-spacing: 1px;
-            color: var(--gray-400);
-            text-transform: uppercase;
-        }
-
-        .voice-modal-title {
-            font-size: 1.25rem;
-            font-weight: 600;
-        }
-
-        .voice-modal-close {
-            background: transparent;
-            border: 1px solid var(--gray-800);
-            color: var(--white);
-            border-radius: 999px;
-            padding: 0.4rem 0.65rem;
-            cursor: pointer;
-            transition: all 0.2s ease;
-        }
-
-        .voice-modal-close:hover {
-            background: rgba(255, 255, 255, 0.08);
-            border-color: var(--white);
-        }
-
-        .voice-modal-body {
-            padding: 1rem 1.25rem 1.25rem;
-            overflow: auto;
-            flex: 1;
-        }
-
-        .voice-widget-mount {
-            width: 100%;
-            min-height: 420px;
-        }
-
-        /* ============================================
            RESPONSIVE
         ============================================ */
         @media (max-width: 1024px) {
@@ -1869,10 +1783,6 @@
                 max-width: 100%;
             }
 
-            .voice-modal {
-                max-width: calc(100% - 3rem);
-            }
-
             .hero-tagline {
                 display: none;
             }
@@ -1911,23 +1821,6 @@
 
             .hero-line.left { left: 1.5rem; }
             .hero-line.right { right: 1.5rem; }
-
-            .voice-modal-backdrop {
-                padding: 0;
-            }
-
-            .voice-modal {
-                width: 100%;
-                height: 100vh;
-                max-height: 100vh;
-                border-radius: 0;
-                border-left: none;
-                border-right: none;
-            }
-
-            .voice-modal-body {
-                padding: 1rem;
-            }
 
             footer {
                 flex-direction: column;
@@ -1975,9 +1868,8 @@
             <li><a href="events.html">Events</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
-            <li><a href="portfolio.html">Work</a></li>
+            <li><a href="portfolio.html">Portfolio</a></li>
             <li><a href="contact.html">Contact</a></li>
-            <li><button type="button" id="voiceAgentButton">Voice Agent</button></li>
         </ul>
     </nav>
     
@@ -2014,27 +1906,13 @@
         </div>
     </section>
 
-    <!-- Story Generator CTA -->
-    <section class="story-generator-cta proto-grid">
-        <div class="story-cta-inner">
-            <div class="story-cta-label proto-text-mono">Core Tool</div>
-            <h2 class="story-cta-title">Story Generator</h2>
-            <p class="story-cta-desc">Roll fast, grab a constraint, and build something shootable. Come back anytime to keep the momentum.</p>
-            <a href="ideas.html" class="story-cta-btn proto-btn">
-                <span>Generate an Idea</span>
-                <span class="story-cta-arrow">→</span>
-            </a>
-        </div>
-    </section>
-
-    <!-- Work -->
+    <!-- Portfolio -->
     <section class="work" id="work">
         <div class="section-header">
-            <span class="section-label proto-text-mono">Selected Work</span>
+            <span class="section-label proto-text-mono">Our Stuff</span>
             <div class="section-line"></div>
             <span class="section-count proto-text-mono">05</span>
         </div>
-        <p class="section-intro">A handful of projects that earned trust and repeat collaborators across Detroit.</p>
 
         <div class="project-grid">
             <a href="portfolio.html#moz" class="project proto-card">
@@ -2127,6 +2005,19 @@
         </div>
     </section>
 
+    <!-- Story Generator CTA -->
+    <section class="story-generator-cta proto-grid">
+        <div class="story-cta-inner">
+            <div class="story-cta-label proto-text-mono">Core Tool</div>
+            <h2 class="story-cta-title">Story Generator</h2>
+            <p class="story-cta-desc">Roll fast, grab a constraint, and build something shootable. Come back anytime to keep the momentum.</p>
+            <a href="ideas.html" class="story-cta-btn proto-btn">
+                <span>Generate an Idea</span>
+                <span class="story-cta-arrow">→</span>
+            </a>
+        </div>
+    </section>
+
     <!-- Resources Section -->
     <section class="resources-section proto-grid" data-source="resources-data">
         <div class="section-header">
@@ -2176,29 +2067,12 @@
         </div>
     </div>
 
-    <!-- Voice Agent Modal -->
-    <div class="voice-modal-backdrop" id="voiceModalBackdrop" aria-hidden="true">
-        <div class="voice-modal" id="voiceModalDialog" role="dialog" aria-modal="true" aria-labelledby="voiceModalTitle" tabindex="-1">
-            <div class="voice-modal-header">
-                <div>
-                    <div class="voice-modal-kicker">Voice Agent</div>
-                    <h3 class="voice-modal-title" id="voiceModalTitle">Chat with LaB Media</h3>
-                </div>
-                <button class="voice-modal-close" id="voiceModalClose" type="button" aria-label="Close Voice Agent">×</button>
-            </div>
-            <div class="voice-modal-body">
-                <div class="voice-widget-mount" id="voiceWidgetMount" role="document" aria-live="polite"></div>
-            </div>
-        </div>
-    </div>
-
     <!-- Footer -->
     <footer>
         <div class="footer-copy">
             © 2025 LaB Media
             <span class="footer-note">Turn project notes into a quick narrated mini-podcast — table-read energy for your ideas, in audio form.</span>
         </div>
-        <a href="#" class="footer-link" id="voiceAgentFooterLink">Voice Agent</a>
         <a href="https://youtube.com/@BobtastiCFPV" class="footer-link" target="_blank" rel="noopener">FPV</a>
         <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" class="footer-link" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
         <a href="plan-your-project.html" class="footer-cta">
@@ -2926,144 +2800,6 @@
                 onEnterBack: () => project.classList.add('in-view'),
                 onLeaveBack: () => project.classList.remove('in-view')
             });
-        });
-
-        // ============================================
-        // VOICE AGENT MODAL & WIDGET
-        // ============================================
-        const voiceAgentButton = document.getElementById('voiceAgentButton');
-        const voiceAgentFooterLink = document.getElementById('voiceAgentFooterLink');
-        const voiceModalBackdrop = document.getElementById('voiceModalBackdrop');
-        const voiceModalDialog = document.getElementById('voiceModalDialog');
-        const voiceModalClose = document.getElementById('voiceModalClose');
-        const voiceWidgetMount = document.getElementById('voiceWidgetMount');
-        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-        const focusableSelectors = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
-        let voiceScriptPromise = null;
-        let lastFocusedElement = null;
-
-        function injectVoiceWidget() {
-            if (voiceWidgetMount.querySelector('elevenlabs-convai')) return;
-            const widget = document.createElement('elevenlabs-convai');
-            widget.setAttribute('agent-id', 'agent_7801kdhgsr5kf0x912w7wdxrm532');
-            voiceWidgetMount.appendChild(widget);
-        }
-
-        function loadVoiceWidgetScript() {
-            if (voiceScriptPromise) return voiceScriptPromise;
-
-            voiceScriptPromise = new Promise((resolve, reject) => {
-                const script = document.createElement('script');
-                script.src = 'https://unpkg.com/@elevenlabs/convai-widget-embed';
-                script.async = true;
-                script.type = 'text/javascript';
-                script.onload = () => {
-                    injectVoiceWidget();
-                    resolve();
-                };
-                script.onerror = reject;
-                document.head.appendChild(script);
-            });
-
-            return voiceScriptPromise;
-        }
-
-        function trapFocus(event) {
-            if (event.key !== 'Tab') return;
-            const focusable = voiceModalDialog.querySelectorAll(focusableSelectors);
-            if (!focusable.length) return;
-
-            const first = focusable[0];
-            const last = focusable[focusable.length - 1];
-
-            if (event.shiftKey && document.activeElement === first) {
-                event.preventDefault();
-                last.focus();
-            } else if (!event.shiftKey && document.activeElement === last) {
-                event.preventDefault();
-                first.focus();
-            }
-        }
-
-        function openVoiceModal(trigger) {
-            lastFocusedElement = trigger || document.activeElement;
-            voiceModalBackdrop.classList.add('is-open');
-            voiceModalBackdrop.setAttribute('aria-hidden', 'false');
-            document.body.style.overflow = 'hidden';
-
-            if (!prefersReducedMotion.matches) {
-                gsap.set(voiceModalDialog, { opacity: 0, scale: 0.98 });
-                gsap.to(voiceModalBackdrop, { opacity: 1, duration: 0.2, ease: 'power1.out' });
-                gsap.to(voiceModalDialog, { opacity: 1, scale: 1, duration: 0.25, ease: 'power2.out' });
-            } else {
-                voiceModalBackdrop.style.opacity = 1;
-                voiceModalDialog.style.opacity = 1;
-            }
-
-            document.addEventListener('keydown', handleVoiceModalKeydown);
-            voiceModalDialog.addEventListener('keydown', trapFocus);
-
-            loadVoiceWidgetScript().catch(() => {});
-
-            requestAnimationFrame(() => {
-                (voiceModalClose || voiceModalDialog).focus({ preventScroll: true });
-            });
-        }
-
-        function closeVoiceModal() {
-            const finishClose = () => {
-                voiceModalBackdrop.classList.remove('is-open');
-                voiceModalBackdrop.setAttribute('aria-hidden', 'true');
-                document.body.style.overflow = '';
-                document.removeEventListener('keydown', handleVoiceModalKeydown);
-                voiceModalDialog.removeEventListener('keydown', trapFocus);
-                voiceModalDialog.style.opacity = '';
-                voiceModalDialog.style.transform = '';
-                voiceModalBackdrop.style.opacity = '';
-
-                if (lastFocusedElement) {
-                    lastFocusedElement.focus({ preventScroll: true });
-                }
-            };
-
-            if (!prefersReducedMotion.matches) {
-                gsap.timeline({ onComplete: finishClose })
-                    .to(voiceModalDialog, { opacity: 0, scale: 0.98, duration: 0.2, ease: 'power2.inOut' })
-                    .to(voiceModalBackdrop, { opacity: 0, duration: 0.2, ease: 'power1.in' }, 0);
-            } else {
-                finishClose();
-            }
-        }
-
-        function handleVoiceModalKeydown(event) {
-            if (event.key === 'Escape') {
-                closeVoiceModal();
-            }
-        }
-
-        function attachModalTrigger(trigger) {
-            if (!trigger) return;
-            trigger.addEventListener('click', (event) => {
-                event.preventDefault();
-                if (navLinks.classList.contains('active')) {
-                    menuToggle.classList.remove('active');
-                    navLinks.classList.remove('active');
-                    menuToggle.setAttribute('aria-expanded', 'false');
-                    document.body.style.overflow = '';
-                }
-                openVoiceModal(trigger);
-            });
-        }
-
-        attachModalTrigger(voiceAgentButton);
-        attachModalTrigger(voiceAgentFooterLink);
-
-        voiceModalClose.addEventListener('click', closeVoiceModal);
-
-        voiceModalBackdrop.addEventListener('click', (event) => {
-            if (event.target === voiceModalBackdrop) {
-                closeVoiceModal();
-            }
         });
 
         // ============================================


### PR DESCRIPTION
### Motivation
- Make the homepage copy less braggy by removing the intro sentence and renaming the highlight section to a more casual label.
- Improve page flow by grouping the Story Generator CTA between Events and the Production Toolkit for clearer ordering.
- Temporarily disable the Voice Agent integration to remove UI noise until a reimplementation is planned.
- Align navigation labels with the section naming by renaming `Work` to `Portfolio` for clarity.

### Description
- Updated `index.html` to change the nav label from `Work` to `Portfolio` and the section label from `Selected Work` to `Our Stuff` and removed the portfolio intro paragraph.
- Moved the Story Generator CTA block so it now appears after the Events preview and before the Production Toolkit resources block in `index.html`.
- Removed Voice Agent UI elements, modal markup, related CSS rules, and the supporting widget/interaction scripts from `index.html` (including `voiceAgentButton`, footer link, modal elements, and the widget-injection code).
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the homepage reorder and Voice Agent removal.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69668c661ac0832789ee34172f2057c1)