### PR TITLE
Simplify index footer bar

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-02-14 | 10:00AM EST
+———————————————————————
+Change: Simplified the index footer to match the nav bar styling and updated the copyright year.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes: Removed promotional footer copy and links, leaving only the location note and copyright.
+Quick test checklist:
+1. Open index.html and confirm the footer is a clean bar with only the two specified text items.
+2. Confirm the footer typography and spacing match the top navigation bar styling.
+3. Confirm the copyright shows 2026.
+4. Open DevTools console on index.html and confirm no errors.
+
 2026-01-13 | 2:15PM EST
 ———————————————————————
 Change: Fixed the Events split layout, synced list/calendar data, and scoped header nav styling to prevent footer nav duplication.

--- a/index.html
+++ b/index.html
@@ -1582,80 +1582,15 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            border-top: 1px solid var(--gray-800);
             gap: 1.5rem;
             flex-wrap: wrap;
         }
 
-        .footer-copy {
+        .footer-text {
             font-family: 'Space Mono', monospace;
-            font-size: 0.6rem;
-            color: var(--gray-600);
-            letter-spacing: 1px;
-        }
-
-        .footer-note {
-            display: block;
-            font-family: 'Space Mono', monospace;
-            font-size: 0.6rem;
-            color: var(--gray-600);
-            letter-spacing: 0.6px;
-        }
-
-        .footer-link {
-            font-family: 'Space Mono', monospace;
-            font-size: 0.6rem;
+            font-size: 0.7rem;
             color: var(--gray-400);
             letter-spacing: 1px;
-            text-transform: uppercase;
-            text-decoration: none;
-            transition: color 0.3s ease, opacity 0.3s ease;
-        }
-
-        .footer-link:hover {
-            color: var(--white);
-            opacity: 0.8;
-        }
-
-        .footer-cta {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            padding: 0.6rem 1.2rem;
-            border: 1px solid var(--gray-800);
-            text-decoration: none;
-            transition: all 0.3s ease;
-            position: relative;
-        }
-
-        .footer-cta-text {
-            font-family: 'Space Mono', monospace;
-            font-size: 0.6rem;
-            color: var(--gray-400);
-            letter-spacing: 1px;
-            text-transform: uppercase;
-            transition: color 0.3s ease;
-        }
-
-        .footer-cta-arrow {
-            font-family: 'Space Mono', monospace;
-            font-size: 0.8rem;
-            color: var(--gray-600);
-            transition: all 0.3s ease;
-        }
-
-        .footer-cta:hover {
-            border-color: var(--white);
-            background: rgba(255, 255, 255, 0.03);
-        }
-
-        .footer-cta:hover .footer-cta-text {
-            color: var(--white);
-        }
-
-        .footer-cta:hover .footer-cta-arrow {
-            color: var(--white);
-            transform: translateX(3px);
         }
 
         /* ============================================
@@ -1827,11 +1762,6 @@
                 gap: 1.5rem;
                 padding: 1.5rem;
                 align-items: flex-start;
-            }
-
-            /* Hide Start Project button on mobile */
-            .footer-cta {
-                display: none;
             }
 
             .scroll-indicator {
@@ -2069,16 +1999,8 @@
 
     <!-- Footer -->
     <footer>
-        <div class="footer-copy">
-            © 2025 LaB Media
-            <span class="footer-note">Turn project notes into a quick narrated mini-podcast — table-read energy for your ideas, in audio form.</span>
-        </div>
-        <a href="https://youtube.com/@BobtastiCFPV" class="footer-link" target="_blank" rel="noopener">FPV</a>
-        <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" class="footer-link" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
-        <a href="plan-your-project.html" class="footer-cta">
-            <span class="footer-cta-text">Start Project</span>
-            <span class="footer-cta-arrow">→</span>
-        </a>
+        <span class="footer-text">Made in Shelby Twp, MI with ❤️</span>
+        <span class="footer-text">© 2026 LaB Media</span>
     </footer>
 
     <!-- Load Events Data -->


### PR DESCRIPTION
### Motivation
- The existing footer on `index.html` was cluttered with promotional copy and extra links that conflicted with the site’s minimal aesthetic.  
- The footer needed to visually match the top navigation bar (same `Space Mono` typography and horizontal rhythm).  
- Outdated copy and CTA were removed to reduce visual noise and prevent competing emphasis with main content.  
- The copyright year needed updating to 2026.

### Description
- Replaced the footer markup in `index.html` with two minimal items: `Made in Shelby Twp, MI with ❤️` and `© 2026 LaB Media`, rendered as `span.footer-text`.  
- Removed the promotional paragraph, external links (`FPV`, `LaB Talk (Beta)`) and the `Start Project` CTA from the footer in `index.html`.  
- Consolidated footer styles by removing the old `footer-copy`, link and CTA rules and adding a single `.footer-text` rule using `Space Mono` and `font-size: 0.7rem`, and removed the footer `border-top`.  
- Added a `CHANGELOG_RUNNING.md` entry documenting the change and committed the updates (`index.html`, `CHANGELOG_RUNNING.md`).

### Testing
- Automated tests: Not run (environment restriction)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669ee943f48327b5d7847a3d89a206)