### PR TITLE
Add Frames & Fabrics website to modal and include event URL in .ics exports

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 8:07PM EST
+———————————————————————
+Change: Added the Frames & Fabrics website to the event bio info and ensured calendar exports include event URLs in the description.
+Files touched: events-data.js, events.html, CHANGELOG_RUNNING.md
+Notes: Event website now displays in the detail modal; exported .ics files append the event URL to the description.
+Quick test checklist:
+1. Open events.html and open the Frames & Fabrics event modal; confirm the Details section lists the website link.
+2. Click “Add to Calendar” for a future event and open the downloaded .ics file to confirm the event URL appears in the description.
+3. Open DevTools console on events.html and confirm no errors.
+
 2026-01-13 | 2:58PM EST
 ———————————————————————
 Change: Updated the Film Detroit Frames & Fabrics event with the official Detroit.gov link and added a local poster thumbnail in the events list.

--- a/events-data.js
+++ b/events-data.js
@@ -70,6 +70,7 @@ const eventsData = [
     location: 'Heilmann Rec Center, 19601 Brock Ave, Detroit, MI 48205',
     venue: 'Heilmann Rec Center',
     url: 'https://detroitmi.gov/events/film-detroits-frames-fabrics-event-art-film-detroit-jan-31',
+    website: 'https://detroitmi.gov/events/film-detroits-frames-fabrics-event-art-film-detroit-jan-31',
     thumbnail: 'images/events/frames-fabrics-2026.svg',
     promoUrl: 'https://www.facebook.com/share/r/1858PXs8By/?mibextid=wwXIfr',
     description: 'Community-focused film event with filmmaking sessions, budget workshops, and makeup/wardrobe sessions.',

--- a/events.html
+++ b/events.html
@@ -2078,6 +2078,17 @@
                     `;
                 }
 
+                if (eventData.website) {
+                    infoHTML += `
+                        <div class="event-info-item">
+                            <div class="event-info-label">Website</div>
+                            <div class="event-info-value">
+                                <a href="${eventData.website}" target="_blank" rel="noopener noreferrer">${eventData.website}</a>
+                            </div>
+                        </div>
+                    `;
+                }
+
                 if (eventData.audience) {
                     infoHTML += `
                         <div class="event-info-item">
@@ -2214,7 +2225,8 @@
 
             // Escape special characters in text fields
             const summary = (evt.title || '').replace(/[,;\\]/g, '\\$&').replace(/\n/g, '\\n');
-            const description = (evt.description || '').replace(/[,;\\]/g, '\\$&').replace(/\n/g, '\\n');
+            const descriptionText = `${evt.description || ''}${evt.url ? `\n\nEvent URL: ${evt.url}` : ''}`;
+            const description = descriptionText.replace(/[,;\\]/g, '\\$&').replace(/\n/g, '\\n');
             const location = (evt.location || '').replace(/[,;\\]/g, '\\$&').replace(/\n/g, '\\n');
 
             // Build event categories based on type


### PR DESCRIPTION
### Motivation
- Ensure the Frames & Fabrics listing shows its official website in the event bio so users can access the source page directly. 
- Make calendar exports more useful by embedding the event URL into the exported `.ics` DESCRIPTION so clients that ignore the `URL` property still surface the link.

### Description
- Added a `website` property to the Frames & Fabrics event record in `events-data.js`.
- Surface `eventData.website` as a "Website" row in the event detail info grid in `events.html` so the link appears in the modal details.
- Updated `exportSingleEventToIcal` in `events.html` to append the event URL into the `DESCRIPTION` text before escaping and generating the `.ics` file while keeping the `URL:` field present.
- Appended an entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a5abf08883279a44c4dd49296e51)