### PR TITLE
Add organizer metadata and show organizer in event modal

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 8:31PM EST
+———————————————————————
+Change: Added organizer details to event modals and refreshed January 2026 event data notes.
+Files touched: events-data.js, events.html, CHANGELOG_RUNNING.md
+Notes: Campfire “In Motion” details now include organizer and doors-open note; Film Detroit entry now shows organizer.
+Quick test checklist:
+1. Open events.html and navigate to January 2026; confirm “In Motion (Part 1 of 3)” and “Frames & Fabrics” appear in the list and calendar.
+2. Open each event modal and confirm the Organizer field displays for Campfire and Film Detroit entries.
+3. Confirm the “In Motion” modal shows the 6:30 PM time with no end time listed.
+4. Open DevTools console on events.html and confirm no errors.
+
 2026-01-13 | 8:07PM EST
 ———————————————————————
 Change: Added the Frames & Fabrics website to the event bio info and ensured calendar exports include event URLs in the description.

--- a/events-data.js
+++ b/events-data.js
@@ -11,6 +11,7 @@ const eventsData = [
   {
     id: 'royal-starr-new-year-mixer-2026-01-13',
     title: 'Royal Starr Filmmaker New Year Mixer',
+    organizer: 'Royal Starr Arts Institute',
     type: 'meetup',
     startDate: '2026-01-13',
     // Facebook/event listings can change—verify before posting hard details
@@ -26,6 +27,7 @@ const eventsData = [
   {
     id: 'royal-starr-mixer-2026-02-10',
     title: 'Royal Starr Filmmaker Community Mixer',
+    organizer: 'Royal Starr Arts Institute',
     type: 'meetup',
     startDate: '2026-02-10',
     location: 'Metro Detroit, MI',
@@ -38,6 +40,7 @@ const eventsData = [
   {
     id: 'royal-starr-mixer-2026-03-10',
     title: 'Royal Starr Filmmaker Community Mixer',
+    organizer: 'Royal Starr Arts Institute',
     type: 'meetup',
     startDate: '2026-03-10',
     location: 'Metro Detroit, MI',
@@ -50,19 +53,21 @@ const eventsData = [
   {
     id: 'campfire-in-motion-2026-01-15',
     title: 'In Motion (Part 1 of 3): Animation on Film',
+    organizer: 'Campfire Film Cooperative',
     type: 'workshop',
     startDate: '2026-01-15',
     startTime: '18:30',
-    location: 'The Scarab Club, 217 Farnsworth St, Detroit, MI 48202',
+    location: 'The Scarab Club, 217 Farnsworth Street, Detroit, MI 48202',
     venue: 'The Scarab Club',
     url: 'https://campfirefilm.org/events',
-    description: 'Campfire Film Cooperative animation series kickoff: “In Motion: Animation on Film.”',
+    description: 'Campfire Film Cooperative series kickoff (Part 1 of 3) focused on animation + film. Doors open at 6:30 PM; no end time listed.',
     verification: 'verified',
     audience: 'Animators, experimental filmmakers, and anyone exploring hand-crafted motion.'
   },
   {
     id: 'frames-and-fabric-film-detroit-2026-01-31',
     title: "Film Detroit's Frames & Fabrics: The Art of Film in Detroit",
+    organizer: 'Film Detroit / City of Detroit',
     type: 'workshop',
     startDate: '2026-01-31',
     startTime: '15:00',

--- a/events.html
+++ b/events.html
@@ -2078,6 +2078,15 @@
                     `;
                 }
 
+                if (eventData.organizer) {
+                    infoHTML += `
+                        <div class="event-info-item">
+                            <div class="event-info-label">Organizer</div>
+                            <div class="event-info-value">${eventData.organizer}</div>
+                        </div>
+                    `;
+                }
+
                 if (eventData.website) {
                     infoHTML += `
                         <div class="event-info-item">


### PR DESCRIPTION
### Motivation
- Ensure event records include explicit organizer info for clarity and attribution across the January 2026 listings.
- Surface organizer details in the event detail modal so users can see who runs an event without following external links.
- Keep data hygiene for recurring Royal Starr listings and refine Campfire/Film Detroit entries to match flyer-specified details.

### Description
- Added `organizer` fields to Royal Starr entries, the Campfire "In Motion" event, and the Film Detroit Frames & Fabrics entry in `events-data.js`.
- Normalized the Campfire location string and expanded its description to note "Doors open at 6:30 PM" while preserving the lack of an end time.
- Updated `events.html` to render an "Organizer" row inside the event info grid when `eventData.organizer` is present.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the change and the quick test checklist.

### Testing
- Automated tests: Not run (environment restriction).
- Manual check: Open `events.html` and navigate to January 2026 and confirm "In Motion (Part 1 of 3)" and "Frames & Fabrics" appear in both the list and calendar.
- Manual check: Open the Campfire and Film Detroit event modals and confirm an "Organizer" field displays and the Campfire modal shows the 6:30 PM doors-open note with no end time.
- Manual check: Open DevTools console on `events.html` and confirm there are no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ab2a06908327a8007621c691aae6)