### PR TITLE
Remove matte frame and widen Trail Dead video

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 3:42PM EST
+———————————————————————
+Change: Removed the Trail Dead video matte framing and widened the video presentation.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Adjusted #horror video wrapper structure and overrides to remove the framed look.
+Quick test checklist:
+1. Open portfolio.html and scroll to Trail Dead; confirm the thumbnail fills the video frame without a matte.
+2. Click play and confirm the video iframe fills the frame with no white border.
+3. Confirm the Trail Dead video appears wider than before and other sections remain unchanged.
+4. Open DevTools console on portfolio.html and confirm no errors.
+
 2026-01-13 | 8:31PM EST
 ———————————————————————
 Change: Added organizer details to event modals and refreshed January 2026 event data notes.

--- a/portfolio.html
+++ b/portfolio.html
@@ -914,7 +914,7 @@
             background: #000;
             position: relative;
             overflow: hidden;
-            --video-max: 560px;
+            --video-max: 860px;
         }
         
         /* Subtle noise texture */
@@ -968,11 +968,52 @@
         #horror .project-details {
             border-top-color: rgba(220, 38, 38, 0.2);
         }
-        
+
+        #horror .section-inner {
+            grid-template-columns: 1.3fr 0.7fr;
+        }
+
         #horror .video-container {
             box-shadow: none;
+            background: transparent;
+            padding: 0;
+            border: 0;
+            position: relative;
+            overflow: hidden;
+            border-radius: 12px;
+            max-width: var(--video-max);
+            height: auto;
+        }
+
+        #horror .video-container::before {
+            content: none !important;
+            display: none !important;
+        }
+
+        #horror .video-aspect-wrapper {
+            position: relative;
+            width: 100%;
             padding-bottom: 41.84%; /* 2.39:1 cinemascope aspect ratio */
-            max-width: 560px;
+            height: 0;
+            overflow: hidden;
+            border-radius: inherit;
+        }
+
+        #horror .video-aspect-wrapper iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+            display: block;
+        }
+
+        #horror .video-placeholder {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border-radius: inherit;
         }
 
         #horror .video-thumb {
@@ -1390,10 +1431,12 @@
             <div class="section-inner">
             <div class="video-side">
                 <div class="video-container">
-                    <button class="video-placeholder" type="button" data-video-id="rtEs8chuDlM" aria-label="Play Backyard Sessions video">
-                        <img class="video-thumb" src="https://img.youtube.com/vi/rtEs8chuDlM/maxresdefault.jpg" alt="Backyard Sessions thumbnail" loading="lazy">
-                        <span class="video-play">▶</span>
-                    </button>
+                    <div class="video-aspect-wrapper">
+                        <button class="video-placeholder" type="button" data-video-id="rtEs8chuDlM" aria-label="Play Backyard Sessions video">
+                            <img class="video-thumb" src="https://img.youtube.com/vi/rtEs8chuDlM/maxresdefault.jpg" alt="Backyard Sessions thumbnail" loading="lazy">
+                            <span class="video-play">▶</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div class="info-side">


### PR DESCRIPTION
### Motivation
- The Trail Dead (#horror) iframe was showing a white matted/frame look because it inherited the global `.video-container` matte; the goal is to target Trail Dead only and remove that matte while keeping the cinemascope aspect and widening the media.
- `loadVideo()` already supports replacing a `.video-aspect-wrapper`, so the markup should match that pattern for a clean iframe swap.

### Description
- Updated the `#horror` markup in `portfolio.html` to wrap the thumbnail/button in a `div.video-aspect-wrapper` so `loadVideo()` can replace it cleanly with an iframe. (`portfolio.html`)
- Added targeted CSS overrides for `#horror` to remove the matte/frame and move the cinemascope ratio to the wrapper, including: `background: transparent`, `padding: 0`, `border: 0`, `box-shadow: none`, disabling any `::before` framing, and `#horror .video-aspect-wrapper` with the `41.84%` padding-bottom ratio. (`portfolio.html`)
- Ensured the iframe and the thumbnail placeholder fully fill the wrapper with `position: absolute; inset: 0; width: 100%; height: 100%; border: 0;` rules. (`portfolio.html`)
- Widened Trail Dead by increasing `--video-max` from `560px` to `860px` and adjusted the section grid for `#horror` to `1.3fr / 0.7fr` so the media side gets slightly more space. (`portfolio.html`)
- Appended a running changelog entry describing the change and manual verification steps. (`CHANGELOG_RUNNING.md`)

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification checklist (also appended to `CHANGELOG_RUNNING.md`):
  1. Open `portfolio.html` and scroll to the Trail Dead section (`#horror`) and confirm the thumbnail fills the video frame with no white matte/frame visible.
  2. Click the play button and confirm the YouTube iframe replaces the wrapper and fills the frame with no white border around the video.
  3. Confirm the Trail Dead video appears wider than before and visually balanced; verify other sections' video styling is unchanged.
  4. Open DevTools on `portfolio.html` and confirm there are no console errors.

Files changed: `portfolio.html`, `CHANGELOG_RUNNING.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ae10b468832782f93644cba261ea)