### PR TITLE
Remove portfolio nav dots; widen Trail Dead video and remove matte

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,28 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 3:56PM EST
+———————————————————————
+Change: Removed the right-side portfolio navigation dots now that the project map is present.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Eliminated dot nav styles, markup, and click/active handlers to avoid duplicate navigation.
+Quick test checklist:
+1. Open portfolio.html and confirm the right-side dot navigation is gone.
+2. Click the Project Map items and confirm each scrolls to the correct section.
+3. Scroll through sections and confirm the Project Map highlights the active section.
+4. Open DevTools console on portfolio.html and confirm no errors.
+
+2026-01-13 | 3:42PM EST
+———————————————————————
+Change: Removed the Trail Dead video matte framing and widened the video presentation.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Adjusted #horror video wrapper structure and overrides to remove the framed look.
+Quick test checklist:
+1. Open portfolio.html and scroll to Trail Dead; confirm the thumbnail fills the video frame without a matte.
+2. Click play and confirm the video iframe fills the frame with no white border.
+3. Confirm the Trail Dead video appears wider than before and other sections remain unchanged.
+4. Open DevTools console on portfolio.html and confirm no errors.
+
 2026-01-13 | 8:31PM EST
 ———————————————————————
 Change: Added organizer details to event modals and refreshed January 2026 event data notes.

--- a/portfolio.html
+++ b/portfolio.html
@@ -150,20 +150,6 @@
             letter-spacing: 1px;
         }
 
-        /* Portfolio Navigation Dots */
-        .portfolio-nav {
-            position: fixed;
-            right: 2.5rem;
-            top: calc(50% + 3.5rem);
-            transform: none;
-            z-index: 998;
-            display: flex;
-            flex-direction: column;
-            gap: 1.2rem;
-            mix-blend-mode: difference;
-            align-items: center;
-        }
-
         .project-map {
             position: fixed;
             left: 3rem;
@@ -206,49 +192,6 @@
 
         .project-map-link.active,
         .project-map-link:hover {
-            color: var(--white);
-        }
-
-        .nav-dot {
-            width: 12px;
-            height: 12px;
-            border: 2px solid var(--gray-600);
-            background: transparent;
-            border-radius: 50%;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            position: relative;
-            padding: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .nav-dot:hover {
-            border-color: var(--white);
-            transform: scale(1.2);
-        }
-
-        .nav-dot.active {
-            border-color: var(--white);
-            background: var(--white);
-        }
-
-        .dot-number {
-            position: absolute;
-            right: 1.8rem;
-            font-family: 'Space Mono', monospace;
-            font-size: 0.6rem;
-            color: var(--gray-600);
-            letter-spacing: 1px;
-            white-space: nowrap;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            pointer-events: none;
-        }
-
-        .nav-dot:hover .dot-number {
-            opacity: 1;
             color: var(--white);
         }
 
@@ -914,7 +857,7 @@
             background: #000;
             position: relative;
             overflow: hidden;
-            --video-max: 560px;
+            --video-max: 860px;
         }
         
         /* Subtle noise texture */
@@ -968,11 +911,52 @@
         #horror .project-details {
             border-top-color: rgba(220, 38, 38, 0.2);
         }
-        
+
+        #horror .section-inner {
+            grid-template-columns: 1.3fr 0.7fr;
+        }
+
         #horror .video-container {
             box-shadow: none;
+            background: transparent;
+            padding: 0;
+            border: 0;
+            position: relative;
+            overflow: hidden;
+            border-radius: 12px;
+            max-width: var(--video-max);
+            height: auto;
+        }
+
+        #horror .video-container::before {
+            content: none !important;
+            display: none !important;
+        }
+
+        #horror .video-aspect-wrapper {
+            position: relative;
+            width: 100%;
             padding-bottom: 41.84%; /* 2.39:1 cinemascope aspect ratio */
-            max-width: 560px;
+            height: 0;
+            overflow: hidden;
+            border-radius: inherit;
+        }
+
+        #horror .video-aspect-wrapper iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+            display: block;
+        }
+
+        #horror .video-placeholder {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border-radius: inherit;
         }
 
         #horror .video-thumb {
@@ -1075,24 +1059,6 @@
 
             .project-map {
                 display: none;
-            }
-
-            /* Portfolio nav on mobile - horizontal at bottom */
-            .portfolio-nav {
-                left: 50%;
-                right: auto;
-                top: auto;
-                bottom: 2rem;
-                transform: translateX(-50%);
-                flex-direction: row;
-                gap: 1rem;
-            }
-
-            .dot-number {
-                top: -1.5rem;
-                left: 50%;
-                right: auto;
-                transform: translateX(-50%);
             }
 
             section {
@@ -1222,25 +1188,6 @@
         <span class="counter-current">01</span>
         <span class="counter-total">/ 05</span>
     </div>
-
-    <!-- Portfolio Navigation Dots -->
-    <nav class="portfolio-nav" id="portfolioNav" aria-label="Jump to project">
-        <button class="nav-dot active" data-target="artist" aria-label="Anthony Brass - Project 1">
-            <span class="dot-number">01</span>
-        </button>
-        <button class="nav-dot" data-target="moz" aria-label="MOZ Interiors - Project 2">
-            <span class="dot-number">02</span>
-        </button>
-        <button class="nav-dot" data-target="pandys" aria-label="The Pandys - Project 3">
-            <span class="dot-number">03</span>
-        </button>
-        <button class="nav-dot" data-target="horror" aria-label="Trail Dead - Project 4">
-            <span class="dot-number">04</span>
-        </button>
-        <button class="nav-dot" data-target="comedy" aria-label="Lookout - Project 5">
-            <span class="dot-number">05</span>
-        </button>
-    </nav>
 
     <aside class="project-map" aria-label="Project map">
         <div class="project-map-title">Project Map</div>
@@ -1390,10 +1337,12 @@
             <div class="section-inner">
             <div class="video-side">
                 <div class="video-container">
-                    <button class="video-placeholder" type="button" data-video-id="rtEs8chuDlM" aria-label="Play Backyard Sessions video">
-                        <img class="video-thumb" src="https://img.youtube.com/vi/rtEs8chuDlM/maxresdefault.jpg" alt="Backyard Sessions thumbnail" loading="lazy">
-                        <span class="video-play">▶</span>
-                    </button>
+                    <div class="video-aspect-wrapper">
+                        <button class="video-placeholder" type="button" data-video-id="rtEs8chuDlM" aria-label="Play Backyard Sessions video">
+                            <img class="video-thumb" src="https://img.youtube.com/vi/rtEs8chuDlM/maxresdefault.jpg" alt="Backyard Sessions thumbnail" loading="lazy">
+                            <span class="video-play">▶</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div class="info-side">
@@ -1510,12 +1459,7 @@
                         }, 250);
                     }
 
-                    // Update portfolio nav dots
                     const sectionId = entry.target.id;
-                    document.querySelectorAll('.nav-dot').forEach(dot => {
-                        dot.classList.toggle('active', dot.dataset.target === sectionId);
-                    });
-
                     document.querySelectorAll('.project-map-link').forEach(link => {
                         link.classList.toggle('active', link.dataset.target === sectionId);
                     });
@@ -1525,17 +1469,6 @@
         
         sections.forEach(section => {
             observer.observe(section);
-        });
-
-        // Portfolio nav dots click handlers
-        document.querySelectorAll('.nav-dot').forEach(dot => {
-            dot.addEventListener('click', () => {
-                const targetId = dot.dataset.target;
-                const targetSection = document.getElementById(targetId);
-                if (targetSection) {
-                    targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
-            });
         });
 
         document.querySelectorAll('.project-map-link').forEach(link => {


### PR DESCRIPTION
### Motivation
- Remove the redundant right-side dot navigation now that the left-side Project Map provides section jumping. 
- Fix the Trail Dead (`#horror`) media presentation by removing the matted/frame look and making the video wider and cinemascope.

### Description
- Removed dot navigation markup and CSS rules for `.portfolio-nav`, `.nav-dot`, and `.dot-number`, and removed mobile overrides related to the dots in `portfolio.html`.
- Stripped dot click handlers and active-toggle code from the section observer so only the Project Map (`.project-map-link`) is updated and used for navigation in `portfolio.html`.
- Updated the `#horror` section in `portfolio.html` by increasing `--video-max` to `860px`, adding a `div.video-aspect-wrapper` around the placeholder, moving the cinemascope ratio to the wrapper, disabling the container matte (`::before`), and adding fill/position rules so the iframe and placeholder fully cover the wrapper.
- Added a changelog entry in `CHANGELOG_RUNNING.md` documenting the nav-dots removal and referencing manual verification steps.

### Testing
- Automated tests: none run due to environment restrictions.  Manual verification steps are listed in `CHANGELOG_RUNNING.md` for confirming the dot nav removal and `#horror` video behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ae10b468832782f93644cba261ea)