### PR TITLE
Remove white matte from portfolio videos and improve Trail Dead layout

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-13 | 9:17PM EST
+———————————————————————
+Change: Removed video matte framing and refreshed the Trail Dead layout for a larger hero video and non-overlapping text.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Cleared video container backgrounds and expanded the Trail Dead grid/media sizing while padding the info column away from the project map.
+Quick test checklist:
+1. Open portfolio.html and play the MOZ, Pandys, Lookout, and Trail Dead videos to confirm no white frames appear.
+2. Scroll to Trail Dead and confirm the summary/details sit clear of the Project Map on the left.
+3. Confirm the Trail Dead video appears larger and aligned as a hero media block.
+4. Open DevTools console on portfolio.html and confirm no errors.
+
 2026-01-13 | 3:42PM EST
 ———————————————————————
 Change: Removed the Trail Dead video matte framing and widened the video presentation.

--- a/portfolio.html
+++ b/portfolio.html
@@ -246,7 +246,7 @@
             padding-bottom: 56.25%;
             height: 0;
             overflow: hidden;
-            background: #000;
+            background: transparent;
             border-radius: 18px;
         }
 
@@ -257,6 +257,16 @@
             left: 0;
             width: 100%;
             height: 100%;
+        }
+
+        .video-container iframe {
+            border: 0;
+            display: block;
+            background: transparent;
+        }
+
+        .video-aspect-wrapper {
+            background: transparent;
         }
 
         .video-placeholder {
@@ -801,11 +811,7 @@
 
         @media (max-width: 640px) {
             #moz .video-container {
-                padding: 8px;
-            }
-
-            #moz .video-container::before {
-                inset: 8px;
+                padding: 0;
             }
 
             #moz .info-side {
@@ -857,7 +863,7 @@
             background: #000;
             position: relative;
             overflow: hidden;
-            --video-max: 860px;
+            --video-max: 1040px;
         }
         
         /* Subtle noise texture */
@@ -913,7 +919,11 @@
         }
 
         #horror .section-inner {
-            grid-template-columns: 1.3fr 0.7fr;
+            grid-template-columns: 0.9fr 1.35fr;
+        }
+
+        #horror .info-side {
+            padding-left: clamp(4rem, 6vw, 7rem);
         }
 
         #horror .video-container {
@@ -1077,6 +1087,10 @@
             .reversed .video-side,
             .reversed .info-side {
                 order: unset;
+            }
+
+            #horror .info-side {
+                padding-left: 0;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Remove the unwanted white/matte frame around embedded videos so playback appears seamless and frameless across all portfolio sections.
- Resolve the Trail Dead section's layout issues by preventing the title/summary from overlapping the left project map and make its video a stronger, more intentional hero media.
- Keep changes surgical and scoped to the portfolio page stylesheet and changelog per project rules.

### Description
- Made video wrappers frameless by setting `.video-container` and `.video-aspect-wrapper` backgrounds to `transparent` and ensuring `iframe` has `border: 0` and `display: block` so embeds render without a white matte; also removed the default `background: #000` from the base `.video-container` rule.`
- Increased the `#horror` (`Trail Dead`) media sizing by changing `--video-max` from `860px` to `1040px`, adjusted the `#horror .section-inner` grid from `1.3fr 0.7fr` to `0.9fr 1.35fr`, and added `padding-left: clamp(4rem, 6vw, 7rem)` to `#horror .info-side` so the text clears the fixed `project-map` area.
- Added a responsive override to remove the `#horror .info-side` left padding under the existing `@media (max-width: 1024px)` breakpoint so mobile/tablet layouts stack without overflow.
- Updated the running changelog by appending a new entry describing the change and a manual quick test checklist, as required by repository guidelines.
- Files touched: `portfolio.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b5feab908327a4bf55fd75729c40)