### PR TITLE
Simplify homepage hero headline

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 2:53AM EST
+———————————————————————
+Change: Simplified the homepage hero headline to keep the intro minimal.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes: Removed the long descriptor from the hero title so the supporting line carries the detail.
+Quick test checklist:
+1. Open index.html and confirm the hero headline is now "LaB Media" with the supporting mission line still visible.
+2. Check the hero section for any layout shifts or overlap at common desktop/mobile widths.
+3. Open DevTools Console and confirm there are no errors on load.
+
 2026-01-16 | 2:18AM EST
 ———————————————————————
 Change: Added orientation copy, updated SEO metadata, and aligned navigation/footers to position LaB as a Metro Detroit filmmaking hub with case studies.

--- a/index.html
+++ b/index.html
@@ -1913,7 +1913,7 @@
                 <span class="hero-pill">Story Generator</span>
                 <span class="hero-pill">Events + Resources</span>
             </div>
-            <h1 class="hero-title">LaB Media — Metro Detroit Creative Studio & Filmmaking Hub</h1>
+            <h1 class="hero-title">LaB Media</h1>
             <div class="hero-mission">LaB is a Metro Detroit–based creative studio sharing filmmaking resources, local events, and production knowledge for filmmakers and collaborators.</div>
         </div>
 


### PR DESCRIPTION
### Motivation
- The homepage hero H1 was overly long and needs to be minimal so the supporting mission line can carry the descriptive context.

### Description
- Shortened the hero title from "LaB Media — Metro Detroit Creative Studio & Filmmaking Hub" to `LaB Media` in `index.html` and appended a corresponding entry to `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969a82ecf048327a8500c61b41faa31)