### PR TITLE
Update homepage hero copy and nav logo

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 5:41AM EST
+———————————————————————
+Change: Updated the homepage hero copy and nav logo to match the latest brand presentation.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes: Removed the hero title text under the PNG, adjusted the mission line, and swapped the nav logo to LaBMedia.png with a larger size.
+Quick test checklist:
+1. Open index.html and confirm the hero logo no longer has “LaB Media” beneath it and the mission line starts with “A Creative Studio.”
+2. Verify the top navigation logo uses LaBMedia.png and appears larger without layout overlap.
+3. Open DevTools Console and confirm there are no errors on load.
+
 2026-01-16 | 2:53AM EST
 ———————————————————————
 Change: Simplified the homepage hero headline to keep the intro minimal.

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
         }
         
         .nav-logo {
-            height: 22px;
+            height: 32px;
             width: auto;
             filter: brightness(0) invert(1);
         }
@@ -1872,7 +1872,7 @@
     <!-- Navigation -->
     <nav>
         <a href="index.html">
-            <img src="images/THELABLOGO.png" alt="LaB Media" class="nav-logo">
+            <img src="images/LaBMedia.png" alt="LaB Media" class="nav-logo">
         </a>
         
         <button class="menu-toggle" id="menuToggle" aria-label="Toggle menu" aria-expanded="false">
@@ -1913,8 +1913,7 @@
                 <span class="hero-pill">Story Generator</span>
                 <span class="hero-pill">Events + Resources</span>
             </div>
-            <h1 class="hero-title">LaB Media</h1>
-            <div class="hero-mission">LaB is a Metro Detroit–based creative studio sharing filmmaking resources, local events, and production knowledge for filmmakers and collaborators.</div>
+            <div class="hero-mission">A Creative Studio for Metro Detroit filmmakers sharing resources, local events, and production knowledge for collaborators.</div>
         </div>
 
         <div class="hero-tagline proto-text-mono">A Creative Studio</div>


### PR DESCRIPTION
### Motivation
- Make the homepage hero match the updated brand presentation by removing the redundant “LaB Media” title under the hero PNG and ensuring the top nav logo uses the new `LaBMedia.png` artwork at a slightly larger size so the mission line can start with “A Creative Studio.”

### Description
- Increased `.nav-logo` size and replaced `images/THELABLOGO.png` with `images/LaBMedia.png` in `index.html`.
- Removed the `<h1 class="hero-title">LaB Media</h1>` and updated the hero copy so the mission line now begins with `A Creative Studio` in `index.html`.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cf5da4e08327964c4a3372ec7fc9)