### PR TITLE
Increase index nav logo size

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 5:55AM EST
+———————————————————————
+Change: Increased the homepage nav logo height to make the LaBMedia.png mark more prominent.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes: Adjusted the nav logo height from 32px to 48px.
+Quick test checklist:
+1. Open index.html and confirm the top nav LaBMedia.png logo appears noticeably larger without overlapping the nav links.
+2. Resize the browser width and confirm the nav still stays aligned with no clipping.
+3. Open DevTools Console and confirm there are no errors on load.
+
 2026-01-16 | 5:41AM EST
 ———————————————————————
 Change: Updated the homepage hero copy and nav logo to match the latest brand presentation.

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
         }
         
         .nav-logo {
-            height: 32px;
+            height: 48px;
             width: auto;
             filter: brightness(0) invert(1);
         }


### PR DESCRIPTION
### Motivation
- Make the LaBMedia.png mark more prominent in the top navigation so the brand reads clearer at typical desktop widths.

### Description
- Increased the `.nav-logo` height from `32px` to `48px` in `index.html` and appended a corresponding entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d2c96e888327aee5d11b477b6afb)