### PR TITLE
Add Ken Burns background for Anthony Brass section

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 6:25AM EST
+———————————————————————
+Change: Added a Ken Burns background image treatment for the Anthony Brass portfolio section.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Applied BrassShoot.jpeg as the section background with a soft gradient overlay for readability.
+Quick test checklist:
+1. Open portfolio.html and confirm the Anthony Brass section shows the new background image with a subtle Ken Burns motion.
+2. Scroll within the Anthony Brass section and confirm text remains legible over the overlay.
+3. Enable prefers-reduced-motion and confirm the background animation stops.
+4. Open DevTools Console and confirm there are no errors.
+
 2026-01-16 | 5:55AM EST
 ———————————————————————
 Change: Increased the homepage nav logo height to make the LaBMedia.png mark more prominent.

--- a/portfolio.html
+++ b/portfolio.html
@@ -544,12 +544,39 @@
            organic shapes, nature colors, rounded corners
         ============================================ */
         #artist {
-            background: linear-gradient(180deg, #f5e6dd 0%, #f9ede6 50%, #fdf4ef 100%);
+            background: #f5e6dd;
+            position: relative;
+            overflow: hidden;
             --video-max: 720px;
+        }
+
+        #artist::before {
+            content: '';
+            position: absolute;
+            top: -6%;
+            left: -6%;
+            width: 112%;
+            height: 112%;
+            background-image: url('images/BrassShoot.jpeg');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            animation: kenBurnsZoom 24s ease-in-out infinite alternate;
+            z-index: 1;
+        }
+
+        #artist::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(245, 230, 221, 0.82) 0%, rgba(249, 237, 230, 0.72) 50%, rgba(253, 244, 239, 0.78) 100%);
+            z-index: 2;
         }
         
         #artist .section-inner {
             gap: 4rem;
+            position: relative;
+            z-index: 3;
         }
         
         #artist .video-container {
@@ -937,6 +964,10 @@
 
         /* Reduced Motion */
         @media (prefers-reduced-motion: reduce) {
+            #artist::before {
+                animation: none !important;
+            }
+
             #moz::before {
                 animation: none !important;
             }


### PR DESCRIPTION
### Motivation
- Showcase the new `images/BrassShoot.jpeg` photo in the Anthony Brass portfolio section using a Ken Burns-style treatment to add color and mirror the MOZ section aesthetic.

### Description
- Added CSS in `portfolio.html` to place the image in `#artist::before` with a Ken Burns zoom animation and a soft gradient overlay in `#artist::after` for readability.
- Set `#artist` to `position: relative` and `overflow: hidden` and raised `.section-inner` with `z-index` so content renders above the background.
- Added reduced-motion support by disabling the animation under `@media (prefers-reduced-motion: reduce)`.
- Appended an entry to `CHANGELOG_RUNNING.md` documenting the change and quick verification steps.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d9925888832797fa389a3673dcfb)