### PR TITLE
Add Detroit Filmmaker Awards bio image to resources modal

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 1:04PM EST
+———————————————————————
+Change: Added Detroit Filmmaker Awards bio image to the resources modal and aligned it beside the features list.
+Files touched: resources-data.js, resources.html, CHANGELOG_RUNNING.md
+Notes: Adds DFAXDFM.JPG image field to the Detroit Filmmaker Awards resource and renders a right-side image column in the modal when a bio image is present.
+Quick test checklist:
+1. Open resources.html and open the Detroit Filmmaker Awards modal.
+2. Confirm the DFAXDFM image appears to the right of the features list.
+3. Resize to mobile width and confirm the image stacks below the features list without layout issues.
+4. Open DevTools console and verify no errors.
+
 2026-01-16 | 1:15AM EST
 ———————————————————————
 Change: UI polish pass - fixed image loading, removed button arrows, toned down portfolio overlays, enlarged beaker icons

--- a/resources-data.js
+++ b/resources-data.js
@@ -184,6 +184,8 @@ const resources = [
         url: 'https://detroitfilmmakerawards.com/',
         filmFreewayUrl: 'https://filmfreeway.com/DetroitFilmmakerAwards',
         paid: true,
+        bioImage: 'images/DFAXDFM.JPG',
+        bioImageAlt: 'Detroit Filmmaker Awards logo',
         keyInfo: [
             { label: 'Location', value: 'Detroit, MI' },
             { label: 'Broadcast', value: 'Local TV' }

--- a/resources.html
+++ b/resources.html
@@ -1407,6 +1407,32 @@
             padding-left: 1rem;
         }
 
+        .modal-feature-media {
+            display: grid;
+            grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+            gap: 1.5rem;
+            align-items: start;
+        }
+
+        .modal-feature-media .modal-section {
+            margin-bottom: 0;
+        }
+
+        .modal-image-col {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .modal-image-col img {
+            width: 100%;
+            max-width: 320px;
+            border: 1px solid var(--gray-800);
+            border-radius: 6px;
+            background: var(--black);
+            object-fit: contain;
+        }
+
         /* Mobile: stack columns */
         @media (max-width: 768px) {
             .modal-two-col {
@@ -1423,6 +1449,20 @@
 
             .modal-two-col .links-col {
                 padding-left: 0;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .modal-feature-media {
+                grid-template-columns: 1fr;
+            }
+
+            .modal-image-col {
+                justify-content: flex-start;
+            }
+
+            .modal-image-col img {
+                max-width: 100%;
             }
         }
 
@@ -3304,6 +3344,20 @@
                     ).join('') + '</div></div>';
             }
 
+            let featuresWithMediaHTML = featuresHTML;
+            if (r.bioImage) {
+                const bioAltText = r.bioImageAlt || (r.name + ' image');
+                const bioImageHTML = '<div class="modal-image-col"><img src="' + r.bioImage + '" alt="' + bioAltText + '"></div>';
+                if (featuresHTML) {
+                    featuresWithMediaHTML = '<div class="modal-feature-media">' +
+                        '<div class="modal-feature-col">' + featuresHTML + '</div>' +
+                        bioImageHTML +
+                    '</div>';
+                } else {
+                    featuresWithMediaHTML = '<div class="modal-feature-media">' + bioImageHTML + '</div>';
+                }
+            }
+
             const ctas = [];
             const addedLinks = new Set();
             const filmFreewayLink = r.filmFreewayUrl || getKeyInfoLink(r, 'filmfreeway');
@@ -3422,7 +3476,7 @@
                     videoHTML +
                     keyInfoHTML +
                     pricingHTML +
-                    featuresHTML +
+                    featuresWithMediaHTML +
                     relatedLinksHTML +
                     ctaHTML;
             }


### PR DESCRIPTION
### Motivation
- Show the newly added `images/DFAXDFM.JPG` asset inside the Resources bio for the Detroit Filmmaker Awards and use the empty right-side column in the modal to display it beside the features list.
- Keep the change surgical and reversible while respecting the existing modal layout and responsive behavior.

### Description
- Added `bioImage` and `bioImageAlt` fields to the Detroit Filmmaker Awards entry in `resources-data.js` so the modal has a data-driven image to render.
- Added CSS rules (`.modal-feature-media`, `.modal-image-col`, responsive media queries) to `resources.html` to support a two-column features + image layout and to stack on small screens.
- Updated the modal rendering logic in `resources.html` to build `featuresWithMediaHTML` when `r.bioImage` exists and inject the image HTML alongside the feature list, then swapped usage of `featuresHTML` for `featuresWithMediaHTML` in the standard modal path.
- Appended a changelog entry to `CHANGELOG_RUNNING.md` documenting the change and quick verification steps.

### Testing
- Automated tests: Not run (environment restriction), an attempted Playwright UI check timed out during screenshot capture.
- Manual verification checklist is recorded in `CHANGELOG_RUNNING.md` (open `resources.html`, open the Detroit Filmmaker Awards modal, confirm the image appears to the right of the features list on desktop and stacks on mobile, and check DevTools for console errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a36e4d0d48327998c183429e00b0e)