### PR TITLE
Make DFA callout tile open an on-page modal and include DFA image in resource bio

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 1:32PM EST
+———————————————————————
+Change: Made the DFA partnership callout open an on-page modal with full details and tuned the DFA resource bio image metadata.
+Files touched: index.html, resources-data.js, CHANGELOG_RUNNING.md
+Notes: The DFA callout on the homepage is now fully clickable and opens a modal with details, image, and close behavior instead of navigating away.
+Quick test checklist:
+1. Open index.html and click anywhere on the DFA callout tile; confirm a modal opens with image, details, and a close button.
+2. Click the backdrop or press ESC to close the modal, then confirm focus returns to the callout tile.
+3. Open resources.html and open the Detroit Filmmaker Awards modal; confirm the DFA image appears in the bio panel.
+4. Open DevTools console on both pages and verify no errors.
+
 2026-01-16 | 1:04PM EST
 ———————————————————————
 Change: Added Detroit Filmmaker Awards bio image to the resources modal and aligned it beside the features list.

--- a/index.html
+++ b/index.html
@@ -440,10 +440,21 @@
             border: 1px solid rgba(255,255,255,0.12);
             background: rgba(255,255,255,0.02);
             transition: border-color 0.2s ease;
+            width: 100%;
+            text-align: left;
+            cursor: pointer;
+            appearance: none;
+            color: inherit;
+            font: inherit;
         }
 
         .dfa-callout-content:hover {
             border-color: rgba(255,255,255,0.2);
+        }
+
+        .dfa-callout-content:focus-visible {
+            outline: none;
+            border-color: rgba(255,255,255,0.35);
         }
 
         .dfa-callout-image {
@@ -1266,6 +1277,42 @@
             border-color: #60A5FA;
         }
 
+        .dfa-modal-grid {
+            display: grid;
+            grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+            gap: 1.5rem;
+            align-items: start;
+        }
+
+        .dfa-modal-image {
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+        }
+
+        .dfa-modal-image img {
+            width: 100%;
+            max-width: 280px;
+            border: 1px solid var(--gray-800);
+            border-radius: 6px;
+            background: var(--black);
+            object-fit: contain;
+        }
+
+        @media (max-width: 768px) {
+            .dfa-modal-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .dfa-modal-image {
+                justify-content: flex-start;
+            }
+
+            .dfa-modal-image img {
+                max-width: 100%;
+            }
+        }
+
         .status-chip {
             display: inline-flex;
             align-items: center;
@@ -2013,14 +2060,14 @@
 
     <!-- Temporary DFA Partnership Callout -->
     <section class="dfa-partnership-callout">
-        <div class="dfa-callout-content">
+        <button class="dfa-callout-content" id="dfaCalloutTrigger" type="button" aria-haspopup="dialog" aria-controls="dfaCalloutBackdrop">
             <img src="images/DFAXDFM.JPG" alt="DFA x Film Detroit" class="dfa-callout-image">
             <div class="dfa-callout-text">
                 <span class="dfa-callout-label">New Partnership</span>
                 <p class="dfa-callout-headline">DFA films now air on Detroit Public Access TV</p>
-                <a href="events.html" class="dfa-callout-link">Learn more →</a>
+                <span class="dfa-callout-link">Learn more →</span>
             </div>
-        </div>
+        </button>
     </section>
 
     <section class="start-here">
@@ -2169,6 +2216,52 @@
         Weekly filmmaker brief signup placeholder.
     </section>
 
+    <!-- DFA Partnership Modal -->
+    <div class="event-preview-backdrop" id="dfaCalloutBackdrop" aria-hidden="true">
+        <div class="event-preview-modal" id="dfaCalloutModal" role="dialog" aria-modal="true" aria-labelledby="dfaCalloutTitle" tabindex="-1">
+            <div class="event-modal-header">
+                <button class="event-modal-close" id="dfaCalloutClose" type="button">ESC</button>
+                <div class="event-modal-chip-row">
+                    <span class="status-chip">Partnership Update</span>
+                </div>
+                <h2 class="event-modal-title" id="dfaCalloutTitle">DFA films now air on Detroit Public Access TV</h2>
+            </div>
+            <div class="event-modal-body">
+                <div class="dfa-modal-grid">
+                    <div>
+                        <div class="event-modal-section">
+                            <h3 class="event-modal-section-title">Details</h3>
+                            <div class="event-info-grid">
+                                <div class="event-info-item">
+                                    <div class="event-info-label">Broadcast</div>
+                                    <div class="event-info-value">Detroit Public Access TV</div>
+                                </div>
+                                <div class="event-info-item">
+                                    <div class="event-info-label">Partner</div>
+                                    <div class="event-info-value">Film Detroit</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="event-modal-section">
+                            <h3 class="event-modal-section-title">About</h3>
+                            <p class="event-modal-description">Detroit Filmmaker Awards films are now airing on Detroit Public Access TV, giving local filmmakers a new broadcast home through DFA's partnership with Film Detroit.</p>
+                        </div>
+                        <div class="event-modal-section">
+                            <h3 class="event-modal-section-title">Links</h3>
+                            <a href="https://detroitfilmmakerawards.com/" target="_blank" rel="noopener noreferrer" class="event-modal-link">
+                                Visit Detroit Filmmaker Awards
+                                <span>→</span>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="dfa-modal-image">
+                        <img src="images/DFAXDFM.JPG" alt="DFA x Film Detroit">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Event Preview Modal -->
     <div class="event-preview-backdrop" id="eventPreviewBackdrop" aria-hidden="true">
         <div class="event-preview-modal" id="eventPreviewModal" role="dialog" aria-modal="true" aria-labelledby="eventModalTitle" tabindex="-1">
@@ -2288,10 +2381,16 @@
         // ============================================
         // EVENT PREVIEW MODAL
         // ============================================
+        const dfaCalloutTrigger = document.getElementById('dfaCalloutTrigger');
+        const dfaCalloutBackdrop = document.getElementById('dfaCalloutBackdrop');
+        const dfaCalloutModal = document.getElementById('dfaCalloutModal');
+        const dfaCalloutClose = document.getElementById('dfaCalloutClose');
+
         const eventPreviewBackdrop = document.getElementById('eventPreviewBackdrop');
         const eventPreviewModal = document.getElementById('eventPreviewModal');
         const eventModalClose = document.getElementById('eventModalClose');
 
+        let lastDfaFocusEl = null;
         let lastEventFocusEl = null;
         let currentEventData = null;
 
@@ -2508,6 +2607,37 @@
             if (lastEventFocusEl && lastEventFocusEl.focus) lastEventFocusEl.focus();
         }
 
+        function openDfaCallout() {
+            if (!dfaCalloutBackdrop) return;
+            lastDfaFocusEl = document.activeElement;
+            dfaCalloutBackdrop.classList.add('is-open');
+            dfaCalloutBackdrop.setAttribute('aria-hidden', 'false');
+            setTimeout(() => {
+                if (dfaCalloutModal) dfaCalloutModal.focus();
+            }, 100);
+        }
+
+        function closeDfaCallout() {
+            if (!dfaCalloutBackdrop) return;
+            dfaCalloutBackdrop.classList.remove('is-open');
+            dfaCalloutBackdrop.setAttribute('aria-hidden', 'true');
+            if (lastDfaFocusEl && lastDfaFocusEl.focus) lastDfaFocusEl.focus();
+        }
+
+        if (dfaCalloutTrigger) {
+            dfaCalloutTrigger.addEventListener('click', openDfaCallout);
+        }
+
+        if (dfaCalloutClose) {
+            dfaCalloutClose.addEventListener('click', closeDfaCallout);
+        }
+
+        if (dfaCalloutBackdrop) {
+            dfaCalloutBackdrop.addEventListener('click', (e) => {
+                if (e.target === dfaCalloutBackdrop) closeDfaCallout();
+            });
+        }
+
         if (eventModalClose) {
             eventModalClose.addEventListener('click', closeEventPreview);
         }
@@ -2519,8 +2649,12 @@
         }
 
         document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape' && eventPreviewBackdrop.classList.contains('is-open')) {
+            if (e.key !== 'Escape') return;
+            if (eventPreviewBackdrop && eventPreviewBackdrop.classList.contains('is-open')) {
                 closeEventPreview();
+            }
+            if (dfaCalloutBackdrop && dfaCalloutBackdrop.classList.contains('is-open')) {
+                closeDfaCallout();
             }
         });
 

--- a/resources-data.js
+++ b/resources-data.js
@@ -185,7 +185,7 @@ const resources = [
         filmFreewayUrl: 'https://filmfreeway.com/DetroitFilmmakerAwards',
         paid: true,
         bioImage: 'images/DFAXDFM.JPG',
-        bioImageAlt: 'Detroit Filmmaker Awards logo',
+        bioImageAlt: 'Detroit Filmmaker Awards x Film Detroit',
         keyInfo: [
             { label: 'Location', value: 'Detroit, MI' },
             { label: 'Broadcast', value: 'Local TV' }


### PR DESCRIPTION
### Motivation
- The DFA partnership callout on the homepage currently navigates away and lacks a dismissible bio-style popup; it should behave like other site items by opening an on-page modal with full details and the image. 
- The Detroit Filmmaker Awards resource should display its bio image and accurate alt text inside the resources modal.

### Description
- Converted the DFA callout into a fully clickable `button` and added an accessible modal (markup, CSS, and JS) that opens/closes and returns focus to the trigger. 
- Added modal layout and styling (`.dfa-modal-grid`, image column, focus states) and JS handlers (`openDfaCallout`, `closeDfaCallout`) to index page behavior. 
- Updated the Detroit Filmmaker Awards `bioImageAlt` in `resources-data.js` so the resources modal shows the DFA image with improved alt text. 
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the change. 
- Files touched: `index.html`, `resources-data.js`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Attempted a Playwright script to open `index.html`, click the DFA callout, and capture a screenshot, but Playwright failed with a browser launch/TargetClosedError so automated tests were not completed (environment restriction / Playwright crash).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3cc640a48327a9d35f69e8306e36)