### PR TITLE
Refine mobile portfolio styling for MOZ and background visibility

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 2:14PM EST
+———————————————————————
+Change: Tuned mobile portfolio styling for the MOZ section and lightened mobile backgrounds for Trail Dead and Lookout.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Added mobile spacing and logo sizing adjustments for MOZ, plus increased mobile background image visibility for Trail Dead and Lookout.
+Quick test checklist:
+1. Open portfolio.html on a phone-sized viewport and scroll to the MOZ section; confirm the logo, video, and info card stack cleanly without the nav overlapping.
+2. On the same viewport, check Trail Dead and Lookout sections; confirm the background art is more visible while text remains readable.
+3. Open DevTools console on portfolio.html and verify no errors.
+
 2026-01-16 | 1:32PM EST
 ———————————————————————
 Change: Made the DFA partnership callout open an on-page modal with full details and tuned the DFA resource bio image metadata.

--- a/portfolio.html
+++ b/portfolio.html
@@ -1401,22 +1401,23 @@
             /* DEMOTE BACKGROUNDS TO AMBIENT TEXTURE */
             section::before,
             section::after {
-                opacity: 0.06 !important;
+                opacity: 0.12 !important;
                 animation: none !important;
             }
 
             /* Specific background overrides */
             #horror::before,
             #horror::after {
-                opacity: 0.05 !important;
+                opacity: 0.18 !important;
             }
 
-            #comedy::before {
-                opacity: 0.08 !important;
+            #comedy::before,
+            #comedy::after {
+                opacity: 0.2 !important;
             }
 
             #artist::before {
-                opacity: 0.06 !important;
+                opacity: 0.12 !important;
             }
 
             /* LEFT-ALIGN ALL TEXT (no centered poetry) */
@@ -1484,6 +1485,10 @@
                 max-width: 100% !important;
             }
 
+            #moz {
+                padding-top: 6rem !important;
+            }
+
             #moz .section-inner {
                 padding: 0 !important;
             }
@@ -1507,8 +1512,12 @@
 
             #moz .moz-masthead {
                 position: static !important;
-                margin-bottom: 1rem !important;
+                margin: 0 0 1.25rem !important;
                 text-align: left !important;
+            }
+
+            #moz .moz-logo {
+                height: 92px !important;
             }
 
             #pandys .project-title,


### PR DESCRIPTION
### Motivation
- The MOZ section looked cramped and overlapped by the fixed nav on small screens and needed spacing and logo sizing improvements. 
- The Trail Dead and Lookout backgrounds were too dim on mobile, obscuring the underlying imagery. 
- Keep changes surgical and purely CSS so the static site remains lightweight and dependency-free.

### Description
- Touched `portfolio.html` and `CHANGELOG_RUNNING.md` and appended the required running changelog entry. 
- Increased ambient background visibility on mobile by raising `section::before`/`::after` opacity and specific overrides for `#horror` (Trail Dead), `#comedy` (Lookout), and `#artist`. 
- Added mobile spacing for MOZ via `#moz { padding-top: 6rem !important; }`, tightened masthead margins, and constrained the mobile logo height with `#moz .moz-logo { height: 92px !important; }`. 
- All edits are CSS-only, minimal, and scoped to mobile media queries to avoid desktop regressions.

### Testing
- Automated tests: Not run (environment restriction). 
- Manual verification checklist: 
  1. Open `portfolio.html` in a phone-sized viewport and scroll to the MOZ section to confirm the masthead/logo no longer overlap the fixed nav and the video/info stack cleanly. 
  2. In the same viewport, scroll to Trail Dead and Lookout and confirm the background art is more visible while text remains readable. 
  3. Confirm the MOZ logo size is reduced and the masthead spacing is applied. 
  4. Open DevTools console on `portfolio.html` and verify there are no errors. 
- The running changelog was updated at the top of `CHANGELOG_RUNNING.md` documenting the change and manual checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a46f97b0083278bd3bf59133464ba)