### PR TITLE
Soften Anthony Brass overlay and mute Lookout color wash

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 5:19PM EST
+———————————————————————
+Change: Softened the Anthony Brass overlay and muted the Lookout color wash to a darker, greener palette.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Reduced the white overlay opacity on Anthony Brass and adjusted Lookout gradients to be less intense.
+Quick test checklist:
+1. Open portfolio.html and confirm the Anthony Brass overlay is lighter without washing out the background.
+2. Scroll to Lookout and confirm the color wash is darker/greener and still readable.
+3. Open DevTools console on portfolio.html and verify no errors.
+
 2026-01-16 | 5:13PM EST
 ———————————————————————
 Change: Updated Supabase submission pages to allow the Supabase endpoint in CSP connect-src.

--- a/portfolio.html
+++ b/portfolio.html
@@ -570,7 +570,7 @@
             position: absolute;
             inset: 0;
             /* Horizontal gradient: stronger opacity left (text area) → lighter right (video area) */
-            background: linear-gradient(90deg, rgba(245, 230, 221, 0.75) 0%, rgba(249, 237, 230, 0.62) 50%, rgba(253, 244, 239, 0.50) 100%);
+            background: linear-gradient(90deg, rgba(245, 230, 221, 0.38) 0%, rgba(249, 237, 230, 0.31) 50%, rgba(253, 244, 239, 0.25) 100%);
             z-index: 2;
         }
         
@@ -1205,7 +1205,7 @@
            SECTION 5: LOOKOUT - Comedy, Bright Energy
         ============================================ */
         #comedy {
-            background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+            background: linear-gradient(135deg, #ead9a2 0%, #c9bb6d 100%);
             position: relative;
             overflow: hidden;
             --video-max: 660px;
@@ -1233,9 +1233,9 @@
             inset: 0;
             background: linear-gradient(
                 135deg,
-                rgba(254, 243, 199, 0.50) 0%,
-                rgba(253, 230, 138, 0.45) 45%,
-                rgba(120, 53, 15, 0.18) 100%
+                rgba(234, 217, 162, 0.40) 0%,
+                rgba(183, 190, 120, 0.35) 45%,
+                rgba(72, 81, 33, 0.22) 100%
             );
             z-index: 2;
             pointer-events: none;


### PR DESCRIPTION
### Motivation

- Reduce the bright white wash over Anthony Brass so the background image reads through, and tone down the overly‑bright yellow wash on Lookout in favor of a darker/greener palette while keeping readable contrast.

### Description

- Reduced the opacity on the `#artist::after` horizontal gradient to lower the white overlay and let the background show through by changing the RGBA stops in `portfolio.html`.
- Muted the Lookout section by updating `#comedy` base gradient colors and the `#comedy::after` gradient RGBA stops to darker/greener tones in `portfolio.html`.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the change and committed both files (`portfolio.html`, `CHANGELOG_RUNNING.md`).

### Testing

- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a730821c0832780a663f2b80b7009)