### PR TITLE
Improve resource suggest access and event submit

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,46 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 5:45PM EST
+———————————————————————
+Change: Added a suggest shortcut on resources and tightened event submission payloads.
+Files touched: resources.html, events.html, CHANGELOG_RUNNING.md
+Notes: The quick filter row now includes a Suggest button and event submissions send normalized optional fields plus source.
+Quick test checklist:
+1. Open resources.html and click Suggest to confirm the modal opens.
+2. Submit a test event on events.html and confirm it completes without a 400 error.
+3. Open DevTools console on resources.html and events.html and verify no errors.
+
+2026-01-16 | 5:30PM EST
+———————————————————————
+Change: Added a Callboard link to the main navigation across key pages.
+Files touched: index.html, resources.html, events.html, ideas.html, plan-your-project.html, portfolio.html, contact.html, past-events.html, CHANGELOG_RUNNING.md
+Notes: Kept the nav link minimal to avoid clutter while making the callboard discoverable.
+Quick test checklist:
+1. Open index.html and confirm the Callboard link appears in the nav.
+2. Click the Callboard link from a few pages (resources, events) and confirm it opens callboard.html.
+3. Open DevTools console on one updated page and verify no errors.
+
+2026-01-16 | 5:25PM EST
+———————————————————————
+Change: Routed resource suggestions through Supabase instead of mailto and allowed the endpoint in the CSP.
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes: The suggest modal now posts to the submit-resource function and shows the review success state.
+Quick test checklist:
+1. Open resources.html, submit a suggestion, and confirm the success message appears.
+2. Verify the suggestion submits without CSP errors in DevTools.
+3. Refresh resources.html, reopen the modal, and ensure the form resets properly.
+
+2026-01-16 | 5:19PM EST
+———————————————————————
+Change: Softened the Anthony Brass overlay and muted the Lookout color wash to a darker, greener palette.
+Files touched: portfolio.html, CHANGELOG_RUNNING.md
+Notes: Reduced the white overlay opacity on Anthony Brass and adjusted Lookout gradients to be less intense.
+Quick test checklist:
+1. Open portfolio.html and confirm the Anthony Brass overlay is lighter without washing out the background.
+2. Scroll to Lookout and confirm the color wash is darker/greener and still readable.
+3. Open DevTools console on portfolio.html and verify no errors.
+
 2026-01-16 | 5:13PM EST
 ———————————————————————
 Change: Updated Supabase submission pages to allow the Supabase endpoint in CSP connect-src.

--- a/contact.html
+++ b/contact.html
@@ -565,6 +565,7 @@
         <ul class="nav-links">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>

--- a/events.html
+++ b/events.html
@@ -1582,6 +1582,7 @@
         <ul class="nav-links">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>
@@ -2390,14 +2391,31 @@
                 }
 
                 try {
+                    const eventName = suggestForm.event_name.value.trim();
+                    const eventType = suggestForm.event_type.value.trim();
+                    const startDate = suggestForm.start_date.value;
+                    const endDate = suggestForm.end_date.value;
+                    const location = suggestForm.location.value.trim();
+                    const linkRaw = suggestForm.link.value.trim();
+                    const notesRaw = suggestForm.notes.value.trim();
+                    const source = suggestForm.source ? suggestForm.source.value.trim() : 'events-page';
+
+                    if (!eventName || !eventType || !startDate || !location) {
+                        if (suggestConfirmation) {
+                            suggestConfirmation.textContent = 'Please complete the required fields.';
+                        }
+                        return;
+                    }
+
                     const payload = {
-                        event_name: suggestForm.event_name.value.trim(),
-                        event_type: suggestForm.event_type.value,
-                        start_date: suggestForm.start_date.value,
-                        end_date: suggestForm.end_date.value || null,
-                        location: suggestForm.location.value.trim(),
-                        link: suggestForm.link.value.trim(),
-                        notes: suggestForm.notes.value.trim(),
+                        event_name: eventName,
+                        event_type: eventType,
+                        start_date: startDate,
+                        end_date: endDate || null,
+                        location,
+                        link: (linkRaw && linkRaw !== 'https://') ? linkRaw : null,
+                        notes: notesRaw || null,
+                        source: source || 'events-page',
                         companyWebsite: suggestForm.companyWebsite.value.trim()
                     };
 

--- a/ideas.html
+++ b/ideas.html
@@ -1710,6 +1710,7 @@
             <ul class="nav-links" id="navLinks">
                 <li><a href="resources.html">Resources</a></li>
                 <li><a href="events.html">Events</a></li>
+                <li><a href="callboard.html">Callboard</a></li>
                 <li><a href="ideas.html" class="active">Ideas</a></li>
                 <li><a href="plan-your-project.html">Plan</a></li>
                 <li><a href="portfolio.html">Reel</a></li>

--- a/index.html
+++ b/index.html
@@ -2018,6 +2018,7 @@
         <ul class="nav-links" id="navLinks">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>

--- a/past-events.html
+++ b/past-events.html
@@ -344,6 +344,7 @@
         <ul class="nav-links">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -1057,6 +1057,7 @@
         <ul class="nav-links">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>

--- a/portfolio.html
+++ b/portfolio.html
@@ -570,7 +570,7 @@
             position: absolute;
             inset: 0;
             /* Horizontal gradient: stronger opacity left (text area) → lighter right (video area) */
-            background: linear-gradient(90deg, rgba(245, 230, 221, 0.75) 0%, rgba(249, 237, 230, 0.62) 50%, rgba(253, 244, 239, 0.50) 100%);
+            background: linear-gradient(90deg, rgba(245, 230, 221, 0.38) 0%, rgba(249, 237, 230, 0.31) 50%, rgba(253, 244, 239, 0.25) 100%);
             z-index: 2;
         }
         
@@ -1205,7 +1205,7 @@
            SECTION 5: LOOKOUT - Comedy, Bright Energy
         ============================================ */
         #comedy {
-            background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+            background: linear-gradient(135deg, #ead9a2 0%, #c9bb6d 100%);
             position: relative;
             overflow: hidden;
             --video-max: 660px;
@@ -1233,9 +1233,9 @@
             inset: 0;
             background: linear-gradient(
                 135deg,
-                rgba(254, 243, 199, 0.50) 0%,
-                rgba(253, 230, 138, 0.45) 45%,
-                rgba(120, 53, 15, 0.18) 100%
+                rgba(234, 217, 162, 0.40) 0%,
+                rgba(183, 190, 120, 0.35) 45%,
+                rgba(72, 81, 33, 0.22) 100%
             );
             z-index: 2;
             pointer-events: none;
@@ -1683,6 +1683,7 @@
         <ul class="nav-links">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>

--- a/resources.html
+++ b/resources.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://dfwgjbjrkwikvqmnzcxx.supabase.co; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com;">
     <title>Resources | Filmmaking Tools & Community Hub — Metro Detroit | LaB Media</title>
     <link rel="canonical" href="https://labmedia.work/resources.html">
 
@@ -2018,6 +2018,7 @@
         <ul class="nav-links">
             <li><a href="resources.html">Resources</a></li>
             <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
             <li><a href="ideas.html">Story Generator</a></li>
             <li><a href="plan-your-project.html">Plan</a></li>
             <li><a href="portfolio.html">Reel</a></li>
@@ -2132,8 +2133,8 @@
 
         <!-- Quick Filters Row -->
         <div class="quickfilter-row" id="quickFilterBar" aria-label="Quick filters">
-            <button class="quickfilter-btn" type="button" data-qf="getting-started">
-                🚀 Getting Started
+            <button class="quickfilter-btn" type="button" id="suggestQuick">
+                + Suggest
             </button>
             <button class="quickfilter-btn" type="button" data-qf="saved">
                 Saved
@@ -2285,8 +2286,8 @@
 
         const quickFilterBar = document.getElementById('quickFilterBar');
         const quickFilterButtons = quickFilterBar ? quickFilterBar.querySelectorAll('.quickfilter-btn') : [];
+        const suggestQuickBtn = document.getElementById('suggestQuick');
         const quickFilters = {
-            'getting-started': false,
             saved: false,
             labPick: false,
             free: false,
@@ -2936,15 +2937,10 @@
             }
 
             // Quick filters (multi-toggle)
-            const wantsGettingStarted = quickFilters['getting-started'];
             const wantsSaved = quickFilters.saved;
             const wantsLabPick = quickFilters.labPick;
             const wantsFree = quickFilters.free;
             const wantsPaid = quickFilters.paid;
-
-            if (wantsGettingStarted) {
-                filtered = filtered.filter(r => r.gettingStarted === true);
-            }
 
             if (wantsSaved) {
                 filtered = filtered.filter(r => isFavoriteId(getResourceId(r)));
@@ -3774,6 +3770,10 @@
             setTimeout(() => document.getElementById('suggestName').focus(), 100);
         }
 
+        if (suggestQuickBtn) {
+            suggestQuickBtn.addEventListener('click', openSuggestModal);
+        }
+
         function closeSuggestModal() {
             suggestModal.classList.add('closing');
             setTimeout(() => {
@@ -3824,35 +3824,47 @@
             }, 300);
         }
 
-        function handleSuggestSubmit(e) {
+        const SUPABASE_URL = 'https://dfwgjbjrkwikvqmnzcxx.supabase.co';
+        const SUPABASE_ANON_KEY = 'sb_publishable__Mrv6qhUoPwuzpFl4b4baA_BQcWgd6e';
+
+        async function handleSuggestSubmit(e) {
             e.preventDefault();
             const form = e.target;
-            const name = form.querySelector('#suggestName').value;
-            const url = form.querySelector('#suggestUrl').value;
-            const category = form.querySelector('#suggestCategory').value;
-            const reason = form.querySelector('#suggestReason').value;
+            const name = form.querySelector('#suggestName').value.trim();
+            const urlRaw = form.querySelector('#suggestUrl').value.trim();
+            const category = form.querySelector('#suggestCategory').value.trim();
+            const reason = form.querySelector('#suggestReason').value.trim();
 
-            // Build mailto link
-            const subject = encodeURIComponent('Resource Suggestion: ' + name);
-            const body = encodeURIComponent(
-                'Resource Suggestion\n' +
-                '==================\n\n' +
-                'Name: ' + name + '\n' +
-                'URL: ' + (url || 'Not provided') + '\n' +
-                'Category: ' + (category || 'Not specified') + '\n\n' +
-                'Why it\'s useful:\n' + (reason || 'Not provided')
-            );
+            const payload = {
+                name,
+                url: (urlRaw && urlRaw !== 'https://') ? urlRaw : null,
+                category: category || null,
+                reason: reason || null,
+                companyWebsite: ''
+            };
 
-            // Open mailto
-            window.location.href = 'mailto:r.baldwin@me.com?subject=' + subject + '&body=' + body;
+            const res = await fetch(`${SUPABASE_URL}/functions/v1/submit-resource`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    apikey: SUPABASE_ANON_KEY,
+                    Authorization: `Bearer ${SUPABASE_ANON_KEY}`
+                },
+                body: JSON.stringify(payload)
+            });
+
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok || !data.ok) {
+                throw new Error(data.error || `Request failed (${res.status})`);
+            }
 
             // Show success state
             const formBody = suggestModal.querySelector('.modal-body');
             formBody.innerHTML = `
                 <div class="suggest-success">
                     <div class="suggest-success-icon">+</div>
-                    <p class="suggest-success-text">Opening your email client...</p>
-                    <p class="suggest-success-sub">Thanks for the suggestion!</p>
+                    <p class="suggest-success-text">Thanks! Submitted for review.</p>
+                    <p class="suggest-success-sub">We’ll add it if it’s a good fit.</p>
                 </div>
             `;
 


### PR DESCRIPTION
### Motivation
- Restore a visible, discoverable way for users to suggest resources from the Resources page and remove the less-used `Getting Started` quick filter. 
- Prevent 400 (Bad Request) responses when submitting suggested events by normalizing the payload and applying minimal required-field validation before calling the Supabase function. 
- Record the changes in the running changelog so deploy/verification steps are clear. 

### Description
- Replaced the `Getting Started` quick filter button with a `+ Suggest` shortcut in `resources.html` and wired `#suggestQuick` to open the existing resource suggestion modal via `openSuggestModal`. 
- Routed the resource suggestion form to the Supabase function by adding `SUPABASE_URL`/`SUPABASE_ANON_KEY` usage and posting a normalized payload to `functions/v1/submit-resource`, treating optional fields as `null` when empty. 
- Tightened the event suggestion flow in `events.html` by extracting form fields into local variables, validating required fields (`event_name`, `event_type`, `start_date`, `location`), and sending a normalized payload (optional fields set to `null`, `source` included) to `functions/v1/submit-event`. 
- Added the Supabase origin to `connect-src` in `resources.html` CSP metadata to allow the fetch to succeed. 
- Updated `CHANGELOG_RUNNING.md` with an entry describing the changes and a short verification checklist. 

### Testing
- Automated tests: none were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a730821c0832780a663f2b80b7009)