### PR TITLE
Add resources hot-tip, refine portfolio mobile layout & pause videos on scroll (remove footer CTAs)

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 6:20PM EST
+———————————————————————
+Change: Added a contextual hot tip panel to resources, tuned mobile layouts on portfolio sections, and paused videos when scrolling away.
+Files touched: resources.html, portfolio.html, CHANGELOG_RUNNING.md
+Notes: Removed footer "Start a Project" CTAs on resources/portfolio, added dynamic section tips on resources, and refined mobile layout rules for MOZ/Trail Dead/Lookout while pausing videos on section exit.
+Quick test checklist:
+1. Open resources.html, switch between categories/subfilters, and confirm the hot tip text updates with each section.
+2. Open portfolio.html on mobile width, confirm MOZ layout stacks cleanly, Trail Dead video fills the frame, and Lookout shows info above video so the background faces are visible.
+3. Play a portfolio video, scroll to the next/previous section, and confirm the video pauses.
+4. Open DevTools console on resources.html and portfolio.html and verify no errors.
+
 2026-01-16 | 5:19PM EST
 ———————————————————————
 Change: Softened the Anthony Brass overlay and muted the Lookout color wash to a darker, greener palette.

--- a/portfolio.html
+++ b/portfolio.html
@@ -1491,11 +1491,16 @@
 
             #moz .section-inner {
                 padding: 0 !important;
+                gap: 1.5rem !important;
             }
 
             #moz .info-side {
                 padding: 1.5rem !important;
-                background: rgba(255, 255, 255, 0.08) !important;
+                max-width: 100% !important;
+                background: rgba(0, 0, 0, 0.6) !important;
+                border: 1px solid rgba(255, 255, 255, 0.12) !important;
+                box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35) !important;
+                backdrop-filter: none !important;
             }
 
             #moz .pull-quote {
@@ -1508,6 +1513,9 @@
             #moz .video-container {
                 max-width: 100% !important;
                 padding: 0 !important;
+                border-radius: 14px !important;
+                overflow: hidden !important;
+                box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5) !important;
             }
 
             #moz .moz-masthead {
@@ -1517,7 +1525,27 @@
             }
 
             #moz .moz-logo {
-                height: 92px !important;
+                height: 72px !important;
+            }
+
+            #moz .project-title {
+                letter-spacing: 0.08em !important;
+            }
+
+            #horror .video-aspect-wrapper {
+                padding-bottom: 56.25% !important;
+            }
+
+            #horror .video-thumb {
+                object-fit: cover !important;
+            }
+
+            #comedy .video-side {
+                order: 1 !important;
+            }
+
+            #comedy .info-side {
+                order: -1 !important;
             }
 
             #pandys .project-title,
@@ -1924,13 +1952,23 @@
         function loadVideo(container, videoId) {
             if (!videoId) return;
             const iframe = document.createElement('iframe');
-            iframe.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+            iframe.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0&enablejsapi=1`;
             iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
             iframe.allowFullscreen = true;
             iframe.loading = 'lazy';
             const target = container.querySelector('.video-aspect-wrapper') || container;
             target.innerHTML = '';
             target.appendChild(iframe);
+        }
+
+        function pauseSectionVideo(section) {
+            const iframe = section.querySelector('iframe');
+            if (!iframe || !iframe.contentWindow) return;
+            iframe.contentWindow.postMessage(JSON.stringify({
+                event: 'command',
+                func: 'pauseVideo',
+                args: []
+            }), '*');
         }
 
         document.querySelectorAll('.video-container').forEach(container => {
@@ -1971,6 +2009,8 @@
                     document.querySelectorAll('.project-map-link').forEach(link => {
                         link.classList.toggle('active', link.dataset.target === sectionId);
                     });
+                } else {
+                    pauseSectionVideo(entry.target);
                 }
             });
         }, observerOptions);
@@ -2050,7 +2090,6 @@
                 <img src="images/yt_logo_fullcolor_white_digital.png" alt="YouTube">
             </a>
         </div>
-        <a href="plan-your-project.html" class="footer-cta">Start a Project</a>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>
     </footer>
 

--- a/resources.html
+++ b/resources.html
@@ -281,6 +281,28 @@
             opacity: 0.85;
         }
 
+        .section-tip {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.85rem 1rem;
+            margin-bottom: 1.25rem;
+            border: 1px solid var(--gray-800);
+            background: rgba(255, 255, 255, 0.02);
+            font-size: 0.8rem;
+            line-height: 1.5;
+            color: var(--gray-400);
+        }
+
+        .section-tip strong {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.65rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: var(--white);
+            white-space: nowrap;
+        }
+
         /* Label flicker animation */
         @keyframes labelFlicker {
             0%, 100% {
@@ -2054,6 +2076,10 @@
         </div>
 
         <div class="filter-hint">Start with a category, then refine with subfilters.</div>
+        <div class="section-tip" id="sectionTip" aria-live="polite">
+            <strong>Hot tip</strong>
+            <span>Film festival links lead to programmer-approved submissions and the best local fit.</span>
+        </div>
         
         <!-- Main Category Filter Row -->
         <div class="filter-row">
@@ -2182,7 +2208,6 @@
                 <img src="images/yt_logo_fullcolor_white_digital.png" alt="YouTube">
             </a>
         </div>
-        <a href="plan-your-project.html" class="footer-cta">Start a Project</a>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>
     </footer>
     
@@ -2262,6 +2287,7 @@
         const countEl = document.getElementById('resourceCount');
         const searchInput = document.getElementById('searchInput');
         const toastEl = document.getElementById('shareToast');
+        const sectionTip = document.getElementById('sectionTip');
 
         // Filter buttons
         const groupButtons = document.querySelectorAll('.filter-btn');
@@ -2989,6 +3015,55 @@
 
             return filtered;
         }
+
+        function updateSectionTip() {
+            if (!sectionTip) return;
+            const tips = {
+                'film-festivals': 'Film festivals are sorted for filmmaker-friendly deadlines and programming that welcomes Midwest stories. Start here to find the right home for your cut.',
+                community: 'Community entries map to real local meetups, casting calls, and groups. We highlight spots that actually respond and keep Detroit creators connected.',
+                stock: {
+                    'all-stock': 'Stock tools cover footage, music, SFX, fonts, and 3D assets. These picks balance quality and usable licenses for indie budgets.',
+                    '3d': '3D assets help you block shots or build sets fast. We prioritize lightweight libraries that don’t lock you into paid tiers.',
+                    fonts: 'Fonts sets are curated for title cards and posters with permissive licensing. These are clean, readable, and quick to deploy.',
+                    stock: 'Footage libraries here offer usable B-roll without bloated subscriptions. We favor packs with clear licensing for short films.',
+                    music: 'Music picks are split by paid/free tiers so you can score quickly without copyright anxiety.',
+                    soundfx: 'SoundFX libraries are picked for clean downloads and clear licensing. Great for quick layers and atmosphere.'
+                },
+                tools: {
+                    'all-tools': 'Tools cover gear, casting, coding, and AI helpers. Each pick is tested for workflow speed and value on a zero-budget run.',
+                    ai: 'AI helpers here are about speed: ideation, notes, and clean-up. We keep the list lean and only share tools we actually use.',
+                    coding: 'Coding tools are for micro-sites, landing pages, and automation. We pick the ones that ship fast without subscriptions.',
+                    drone: 'Drone tools include FAA basics, training, and vendors. We focus on safety-first resources with local relevance.',
+                    gear: 'Gear picks are practical and repeatable in the field. We skip the hype and list dependable tools.',
+                    casting: 'Casting tools are chosen for response rate and local reach so you can find talent fast.'
+                },
+                collaborators: 'Friends are trusted local collaborators who have already delivered. Expect real people, real work, and fair rates.',
+                references: {
+                    all: 'Reference libraries are for taste, color, and technique. We curated the ones that inspire strong creative direction.',
+                    inspiration: 'Inspiration feeds for mood, story, and vibe. Use these to reset your creative compass.',
+                    color: 'Color references help lock palette decisions fast. We favor archives with clear, scrollable stills.',
+                    art: 'Art references support production design and poster direction. These are dense and curated.',
+                    editing: 'Editing references showcase rhythm, pacing, and transitions. Great for tightening your cut.',
+                    filming: 'Filming references focus on lighting and framing. Use them to match visual targets.',
+                    music: 'Music references help tone-set your score with clean, legal listening.',
+                    comedy: 'Comedy references are a quick gut-check for timing and punchline structure.'
+                },
+                drones: 'Drone resources cover Part 107, local vendors, and training. We keep this list lean so you fly legal and safe.'
+            };
+
+            let tipText = tips[currentGroup] || tips['film-festivals'];
+            if (currentGroup === 'stock' && tips.stock) {
+                tipText = tips.stock[stockSubcategory] || tips.stock['all-stock'];
+            }
+            if (currentGroup === 'tools' && tips.tools) {
+                tipText = tips.tools[toolsSubcategory] || tips.tools['all-tools'];
+            }
+            if (currentGroup === 'references' && tips.references) {
+                tipText = tips.references[referencesSubcategory] || tips.references.all;
+            }
+
+            sectionTip.querySelector('span').textContent = tipText;
+        }
         
         // ============================================
         // GHOST TILE LOGIC
@@ -3107,6 +3182,7 @@
             const count = filtered.length;
 
             logReferencesDebug(count);
+            updateSectionTip();
 
             // Update count with animation
             animateCount(count);


### PR DESCRIPTION
### Motivation
- Provide context to resource categories by adding an inline “Hot tip” that explains the active section and our recommendations. 
- Improve portfolio mobile UX so problematic sections (MOZ, Trail Dead, Lookout) stack and display correctly on phones. 
- Stop background playback when the user scrolls away from a playing portfolio video and remove redundant footer CTAs.

### Description
- Added a small tip panel UI and styles to `resources.html` and a new `updateSectionTip()` JS function that updates tip copy based on `currentGroup`/subfilters; the call is wired into the existing rendering flow (`renderResources`).
- Tuned mobile CSS for the portfolio in `portfolio.html` to improve MOZ stacking, adjust `#horror` (Trail Dead) video aspect and thumbnail fit, and swap Lookout info/video ordering on mobile so faces remain visible.
- Updated the portfolio video loader to include `enablejsapi=1`, added `pauseSectionVideo()` which posts a pause command to YouTube if a section scrolls out of view, and updated the `IntersectionObserver` to call it when entries exit.
- Removed the footer "Start a Project" CTA anchors from `resources.html` and `portfolio.html` and appended a changelog entry to `CHANGELOG_RUNNING.md` documenting the changes.
- Files changed: `resources.html`, `portfolio.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a80e8e71c8327bddcb305ec77f441)