### PR TITLE
Polish mobile portfolio layout; unify footers and align Callboard nav

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 7:13PM EST
+———————————————————————
+Change: Refined mobile layout fixes on the portfolio page, aligned callboard navigation with the main site, and unified footer layout/placement across resources, ideas, events, plan, and contact.
+Files touched: portfolio.html, resources.html, ideas.html, events.html, plan-your-project.html, contact.html, callboard.html, CHANGELOG_RUNNING.md
+Notes: Updated MOZ mobile stacking, swapped Lookout mobile order, expanded Trail Dead mobile coverage, moved footer social icons left on resources, and matched footer layout across key pages with consistent nav styling.
+Quick test checklist:
+1. Open portfolio.html on a mobile viewport, confirm MOZ stacks cleanly, Trail Dead fills the screen without clipped edges, and Lookout shows video before text so background faces stay visible.
+2. Open resources.html and confirm the Instagram icon sits on the far left of the footer; verify layout spacing remains balanced at desktop and mobile widths.
+3. Open ideas.html, events.html, plan-your-project.html, and contact.html to confirm footer layout matches resources and icons are left-aligned on desktop, centered on mobile.
+4. Open callboard.html and confirm the top navigation uses the full link row matching other pages.
+5. Open DevTools console on portfolio.html, resources.html, and callboard.html to verify no errors.
+
 2026-01-16 | 6:20PM EST
 ———————————————————————
 Change: Added a contextual hot tip panel to resources, tuned mobile layouts on portfolio sections, and paused videos when scrolling away.

--- a/callboard.html
+++ b/callboard.html
@@ -104,6 +104,29 @@
             opacity: 0.5;
         }
 
+        .nav-links {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav-links a {
+            color: var(--white);
+            text-decoration: none;
+            font-family: 'Space Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            transition: opacity 0.3s ease;
+        }
+
+        .nav-links a:hover {
+            opacity: 0.5;
+        }
+
         .page {
             padding: 8rem 6vw 5rem;
             max-width: 1100px;
@@ -377,7 +400,15 @@
         <a href="index.html" aria-label="LaB Media home">
             <img src="images/WhiteBeakerLogo.png" alt="LaB Media" class="nav-logo">
         </a>
-        <a href="index.html" class="nav-back">Back to Home</a>
+        <ul class="nav-links">
+            <li><a href="resources.html">Resources</a></li>
+            <li><a href="events.html">Events</a></li>
+            <li><a href="callboard.html">Callboard</a></li>
+            <li><a href="ideas.html">Story Generator</a></li>
+            <li><a href="plan-your-project.html">Plan</a></li>
+            <li><a href="portfolio.html">Reel</a></li>
+            <li><a href="contact.html">Contact</a></li>
+        </ul>
     </nav>
 
     <main class="page">

--- a/contact.html
+++ b/contact.html
@@ -460,6 +460,7 @@
             text-align: center;
             background: var(--black);
             margin-top: 4rem;
+            position: relative;
         }
 
         .footer-nav {
@@ -486,9 +487,12 @@
 
         .footer-social {
             display: flex;
-            justify-content: center;
+            justify-content: flex-start;
             gap: 1rem;
-            margin-bottom: 1.5rem;
+            position: absolute;
+            left: 2rem;
+            top: 3rem;
+            align-items: center;
         }
 
         .footer-social a {
@@ -530,6 +534,14 @@
         .footer-credit {
             font-size: 0.7rem;
             color: var(--gray-600);
+        }
+
+        @media (max-width: 768px) {
+            .footer-social {
+                position: static;
+                justify-content: center;
+                margin: 1.25rem 0;
+            }
         }
 
         .site-nav .nav-links {

--- a/events.html
+++ b/events.html
@@ -1628,7 +1628,7 @@
         /* Social icons in footer */
         .footer-social {
             position: absolute;
-            right: 2rem;
+            left: 2rem;
             top: 3rem;
             display: flex;
             gap: 1rem;

--- a/ideas.html
+++ b/ideas.html
@@ -1154,20 +1154,23 @@
         /* ============================================
            FOOTER
         ============================================ */
-        .footer {
-            padding: 3rem 0;
+        .site-footer {
+            padding: 3rem 2rem;
             border-top: 1px solid var(--gray-800);
             text-align: center;
+            background: var(--black);
+            position: relative;
         }
 
-        .footer-links {
+        .footer-nav {
             display: flex;
             justify-content: center;
             gap: 2rem;
             margin-bottom: 1.5rem;
+            flex-wrap: wrap;
         }
 
-        .footer-links a {
+        .footer-nav a {
             font-family: 'Space Mono', monospace;
             font-size: 0.65rem;
             color: var(--gray-600);
@@ -1177,15 +1180,17 @@
             transition: color 0.3s ease;
         }
 
-        .footer-links a:hover {
+        .footer-nav a:hover {
             color: var(--white);
         }
 
         .footer-social {
             display: flex;
-            justify-content: center;
             gap: 1rem;
-            margin-bottom: 1.25rem;
+            position: absolute;
+            left: 2rem;
+            top: 3rem;
+            align-items: center;
         }
 
         .footer-social a {
@@ -1207,6 +1212,18 @@
         .footer-credit {
             font-size: 0.7rem;
             color: var(--gray-600);
+        }
+
+        @media (max-width: 768px) {
+            .footer-social {
+                position: static;
+                justify-content: center;
+                margin-top: 1.25rem;
+            }
+
+            .footer-nav {
+                gap: 1rem;
+            }
         }
 
         /* ============================================
@@ -1894,8 +1911,8 @@
         </section>
 
         <!-- Footer -->
-        <footer class="footer">
-            <div class="footer-links">
+        <footer class="site-footer">
+            <div class="footer-nav">
                 <a href="index.html">Home</a>
                 <a href="portfolio.html">Reel</a>
                 <a href="resources.html">Resources</a>

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -998,7 +998,7 @@
 
         .footer-social {
             position: absolute;
-            right: 2rem;
+            left: 2rem;
             top: 3rem;
             display: flex;
             gap: 1rem;

--- a/portfolio.html
+++ b/portfolio.html
@@ -1486,46 +1486,60 @@
             }
 
             #moz {
-                padding-top: 6rem !important;
+                padding-top: 4.5rem !important;
+                padding-bottom: 3.5rem !important;
             }
 
             #moz .section-inner {
                 padding: 0 !important;
-                gap: 1.5rem !important;
+                gap: 1.25rem !important;
             }
 
             #moz .info-side {
-                padding: 1.5rem !important;
+                padding: 1.25rem !important;
                 max-width: 100% !important;
-                background: rgba(0, 0, 0, 0.6) !important;
-                border: 1px solid rgba(255, 255, 255, 0.12) !important;
-                box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35) !important;
+                background: rgba(0, 0, 0, 0.72) !important;
+                border: 1px solid rgba(184, 150, 109, 0.35) !important;
+                box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35) !important;
                 backdrop-filter: none !important;
             }
 
             #moz .pull-quote {
                 position: static !important;
-                margin-top: 1.5rem !important;
+                margin-top: 1rem !important;
                 max-width: 100% !important;
                 text-align: left !important;
+            }
+
+            #moz .pull-quote-text {
+                font-size: 0.8rem !important;
+                letter-spacing: 0.12em !important;
+                padding: 0.9rem 1rem !important;
             }
 
             #moz .video-container {
                 max-width: 100% !important;
                 padding: 0 !important;
-                border-radius: 14px !important;
+                border-radius: 12px !important;
                 overflow: hidden !important;
-                box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5) !important;
+                box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45) !important;
+            }
+
+            #moz .photo-credit {
+                position: static !important;
+                margin-top: 0.75rem !important;
+                text-align: left !important;
+                opacity: 0.6 !important;
             }
 
             #moz .moz-masthead {
                 position: static !important;
-                margin: 0 0 1.25rem !important;
+                margin: 0 0 0.75rem !important;
                 text-align: left !important;
             }
 
             #moz .moz-logo {
-                height: 72px !important;
+                height: 84px !important;
             }
 
             #moz .project-title {
@@ -1540,12 +1554,20 @@
                 object-fit: cover !important;
             }
 
+            #horror {
+                min-height: 100svh;
+            }
+
+            #horror .video-container {
+                border-radius: 0 !important;
+            }
+
             #comedy .video-side {
-                order: 1 !important;
+                order: -1 !important;
             }
 
             #comedy .info-side {
-                order: -1 !important;
+                order: 1 !important;
             }
 
             #pandys .project-title,

--- a/resources.html
+++ b/resources.html
@@ -1886,7 +1886,7 @@
 
         .footer-social {
             position: absolute;
-            right: 2rem;
+            left: 2rem;
             top: 3rem;
             display: flex;
             gap: 1rem;


### PR DESCRIPTION
### Motivation
- Improve mobile presentation for several portfolio pieces (MOZ, Trail Dead, Lookout) so videos and background imagery behave and faces are visible. 
- Make footer social icon placement consistent across key pages for balanced desktop layout and centered mobile layout. 
- Ensure the Callboard page header matches the rest of the site navigation instead of a single back link.

### Description
- Tweaked mobile CSS for the portfolio `#moz`, `#horror` (Trail Dead), and `#comedy` (Lookout) sections to adjust stacking, padding, radius, pull-quote sizing, and video ordering so mobile layout is cleaner (`portfolio.html`).
- Expanded mobile coverage for Trail Dead by enforcing a full-viewport minimum and removing border-radius on the video container to avoid clipped edges (`portfolio.html`).
- Moved footer social icons from the right to the left on desktop and kept them centered on mobile by changing footer rules across pages (`resources.html`, `events.html`, `plan-your-project.html`, `ideas.html`, `contact.html`).
- Normalized the ideas footer to use the same `site-footer` / `footer-nav` pattern as other pages and adjusted responsive rules (`ideas.html`).
- Replaced the Callboard top link with the full site navigation row and added matching nav styles so the header matches other pages (`callboard.html`).
- Appended an entry documenting these updates to `CHANGELOG_RUNNING.md` as required by project ops rules (`CHANGELOG_RUNNING.md`).

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a8ca73c0883279426e43042f1ec69)