### PR TITLE
Improve form submission feedback; fix Events poster, Plan footer, and Anthony Brass overlay

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,24 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 9:22PM EST
+———————————————————————
+Change: Added clearer submission feedback on forms, fixed Events poster image, corrected Plan page footer nav duplication, and darkened Anthony Brass overlay.
+Files touched: events-data.js, events.html, callboard.html, resources.html, plan-your-project.html, portfolio.html, CHANGELOG_RUNNING.md
+Notes:
+1. Added animated status messaging for Callboard, Events, and Resources form submissions to make success/error states obvious.
+2. Updated the Frames & Fabrics poster to use the correct JPG asset.
+3. Replaced the Plan Your Project footer nav element to stop the fixed header duplication.
+4. Adjusted the Anthony Brass overlay/shadow to a darker, woodier tone.
+Quick test checklist:
+1. Open events.html → Submit Event → verify “Sending…” status animation, then “Submitted for review,” and modal closes after a short delay.
+2. Open callboard.html → Submit a Listing → verify status message animates and confirms submission.
+3. Open resources.html → Suggest a Resource → verify sending state and success confirmation animation before auto-close.
+4. Open events.html → Posters → confirm Frames & Fabrics poster image loads.
+5. Open plan-your-project.html → verify only one header nav appears and links are clickable.
+6. Open portfolio.html → Anthony Brass section → confirm darker overlay and less floaty video card styling.
+7. Open DevTools console on events.html, callboard.html, resources.html, plan-your-project.html, and portfolio.html → confirm no errors.
+
 2026-01-17 | 12:15AM EST
 ———————————————————————
 Change: Documentation overhaul, MOZ mobile fix, and SEO updates

--- a/callboard.html
+++ b/callboard.html
@@ -232,6 +232,11 @@
             opacity: 0.7;
         }
 
+        .submit-btn.is-loading {
+            opacity: 0.7;
+            cursor: progress;
+        }
+
         .listings {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -295,6 +300,26 @@
             border: 1px solid var(--gray-800);
             background: var(--gray-900);
             color: var(--gray-400);
+        }
+        .status-message.is-sending {
+            color: var(--gray-300);
+            animation: statusPulse 1.2s ease-in-out infinite;
+        }
+        .status-message.is-success {
+            color: var(--white);
+            animation: statusReveal 0.35s ease;
+        }
+        .status-message.is-error {
+            color: #fca5a5;
+            animation: statusReveal 0.35s ease;
+        }
+        @keyframes statusPulse {
+            0%, 100% { opacity: 0.4; }
+            50% { opacity: 1; }
+        }
+        @keyframes statusReveal {
+            from { opacity: 0; transform: translateY(4px); }
+            to { opacity: 1; transform: translateY(0); }
         }
 
         .modal {
@@ -651,9 +676,21 @@
             if (event.target === modal) closeModalView();
         });
 
+        const setFormStatus = (message, state) => {
+            formStatus.textContent = message;
+            formStatus.classList.remove('is-sending', 'is-success', 'is-error');
+            if (state) formStatus.classList.add(`is-${state}`);
+        };
+
         listingForm.addEventListener('submit', async (event) => {
             event.preventDefault();
-            formStatus.textContent = 'Submitting...';
+            const submitBtn = listingForm.querySelector('button[type="submit"]');
+            setFormStatus('Submitting...', 'sending');
+            listingForm.setAttribute('aria-busy', 'true');
+            if (submitBtn) {
+                submitBtn.disabled = true;
+                submitBtn.classList.add('is-loading');
+            }
 
             const payload = {
                 title: listingForm.title.value.trim(),
@@ -682,10 +719,16 @@
                     throw new Error('Request failed');
                 }
 
-                formStatus.textContent = 'Submitted for approval.';
+                setFormStatus('Submitted for approval.', 'success');
                 listingForm.reset();
             } catch (error) {
-                formStatus.textContent = 'Something went wrong. Please try again in a moment.';
+                setFormStatus('Something went wrong. Please try again in a moment.', 'error');
+            } finally {
+                listingForm.removeAttribute('aria-busy');
+                if (submitBtn) {
+                    submitBtn.disabled = false;
+                    submitBtn.classList.remove('is-loading');
+                }
             }
         });
 

--- a/events-data.js
+++ b/events-data.js
@@ -123,6 +123,6 @@ const eventsPosterData = [
         website: 'https://detroitmi.gov/',
         verification: 'tbd',
         verificationLabel: 'Check site',
-        posterImage: 'images/events/frames-fabrics-2026.svg'
+        posterImage: 'images/Framesnfabricflyer.JPG'
     }
 ];

--- a/events.html
+++ b/events.html
@@ -1217,6 +1217,36 @@
             cursor: pointer;
             font-family: 'Space Mono', monospace;
         }
+        .suggest-submit.is-loading {
+            opacity: 0.7;
+            cursor: progress;
+        }
+        .suggest-confirmation {
+            min-height: 1.2rem;
+            margin-top: 0.5rem;
+            font-size: 0.8rem;
+            color: var(--gray-400);
+        }
+        .suggest-confirmation.is-sending {
+            color: var(--gray-300);
+            animation: statusPulse 1.2s ease-in-out infinite;
+        }
+        .suggest-confirmation.is-success {
+            color: var(--white);
+            animation: statusReveal 0.35s ease;
+        }
+        .suggest-confirmation.is-error {
+            color: #fca5a5;
+            animation: statusReveal 0.35s ease;
+        }
+        @keyframes statusPulse {
+            0%, 100% { opacity: 0.4; }
+            50% { opacity: 1; }
+        }
+        @keyframes statusReveal {
+            from { opacity: 0; transform: translateY(4px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
         /* Event Preview Modal */
         .event-preview-backdrop {
             position: fixed;
@@ -2562,10 +2592,22 @@
         document.addEventListener('keydown', trapFocus);
 
         if (suggestForm) {
+            const suggestSubmitBtn = suggestForm.querySelector('.suggest-submit');
+
+            const setSuggestStatus = (message, state) => {
+                if (!suggestConfirmation) return;
+                suggestConfirmation.textContent = message;
+                suggestConfirmation.classList.remove('is-sending', 'is-success', 'is-error');
+                if (state) suggestConfirmation.classList.add(`is-${state}`);
+            };
+
             suggestForm.addEventListener('submit', async (event) => {
                 event.preventDefault();
-                if (suggestConfirmation) {
-                    suggestConfirmation.textContent = 'Sending...';
+                setSuggestStatus('Sending...', 'sending');
+                suggestForm.setAttribute('aria-busy', 'true');
+                if (suggestSubmitBtn) {
+                    suggestSubmitBtn.disabled = true;
+                    suggestSubmitBtn.classList.add('is-loading');
                 }
 
                 try {
@@ -2579,9 +2621,7 @@
                     const source = suggestForm.source ? suggestForm.source.value.trim() : 'events-page';
 
                     if (!eventName || !eventType || !startDate || !location) {
-                        if (suggestConfirmation) {
-                            suggestConfirmation.textContent = 'Please complete the required fields.';
-                        }
+                        setSuggestStatus('Please complete the required fields.', 'error');
                         return;
                     }
 
@@ -2611,18 +2651,21 @@
 
                     if (response.ok && data.ok !== false) {
                         suggestForm.reset();
-                        if (suggestConfirmation) {
-                            suggestConfirmation.textContent = 'Submitted for review.';
-                        }
-                        closeSuggestModal();
+                        setSuggestStatus('Submitted for review.', 'success');
+                        setTimeout(() => {
+                            closeSuggestModal();
+                            setSuggestStatus('', null);
+                        }, 1500);
                     } else {
-                        if (suggestConfirmation) {
-                            suggestConfirmation.textContent = data.error || 'Submission failed. Please try again shortly.';
-                        }
+                        setSuggestStatus(data.error || 'Submission failed. Please try again shortly.', 'error');
                     }
                 } catch (error) {
-                    if (suggestConfirmation) {
-                        suggestConfirmation.textContent = 'Submission failed. Please try again shortly.';
+                    setSuggestStatus('Submission failed. Please try again shortly.', 'error');
+                } finally {
+                    suggestForm.removeAttribute('aria-busy');
+                    if (suggestSubmitBtn) {
+                        suggestSubmitBtn.disabled = false;
+                        suggestSubmitBtn.classList.remove('is-loading');
                     }
                 }
             });

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -1650,7 +1650,7 @@ Submitted: ${new Date().toLocaleString()}
 
     <!-- Footer -->
     <footer class="site-footer">
-        <nav class="footer-nav">
+        <div class="footer-nav" aria-label="Footer navigation">
             <a href="index.html">Home</a>
             <a href="portfolio.html">Reel</a>
             <a href="resources.html">Resources</a>
@@ -1658,7 +1658,7 @@ Submitted: ${new Date().toLocaleString()}
             <a href="ideas.html">Story Generator</a>
             <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
-        </nav>
+        </div>
         <div class="footer-social" aria-label="LaB social links">
             <a href="https://www.instagram.com/labmedia.work/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
                 <img src="images/Instagram_Glyph_Gradient.png" alt="Instagram">

--- a/portfolio.html
+++ b/portfolio.html
@@ -569,8 +569,8 @@
             content: '';
             position: absolute;
             inset: 0;
-            /* Horizontal gradient: stronger opacity left (text area) → lighter right (video area) */
-            background: linear-gradient(90deg, rgba(245, 230, 221, 0.38) 0%, rgba(249, 237, 230, 0.31) 50%, rgba(253, 244, 239, 0.25) 100%);
+            /* Dark brown veil: stronger opacity left (text area) → lighter right (video area) */
+            background: linear-gradient(90deg, rgba(62, 40, 28, 0.55) 0%, rgba(62, 40, 28, 0.4) 55%, rgba(62, 40, 28, 0.3) 100%);
             z-index: 2;
         }
         
@@ -595,7 +595,8 @@
         #artist .video-container {
             border-radius: 24px;
             overflow: hidden;
-            box-shadow: 0 30px 60px rgba(180, 100, 80, 0.15);
+            box-shadow: 0 18px 36px rgba(62, 40, 28, 0.35);
+            border: 1px solid rgba(62, 40, 28, 0.4);
             max-width: 720px;
         }
         

--- a/resources.html
+++ b/resources.html
@@ -791,6 +791,11 @@
             margin-top: 0.5rem;
         }
 
+        .suggest-submit.is-loading {
+            opacity: 0.7;
+            cursor: progress;
+        }
+
         .suggest-submit span {
             transition: transform 0.3s ease;
         }
@@ -807,9 +812,33 @@
             transform: scale(0.98);
         }
 
+        .suggest-status {
+            min-height: 1.2rem;
+            font-size: 0.8rem;
+            color: var(--gray-400);
+        }
+
+        .suggest-status.is-sending {
+            color: var(--gray-300);
+            animation: statusPulse 1.2s ease-in-out infinite;
+        }
+
+        .suggest-status.is-success {
+            color: var(--white);
+            animation: statusReveal 0.35s ease;
+        }
+
+        .suggest-status.is-error {
+            color: #fca5a5;
+            animation: statusReveal 0.35s ease;
+        }
+
         .suggest-success {
             text-align: center;
             padding: 2rem 0;
+            border: 1px solid var(--gray-800);
+            background: var(--gray-900);
+            animation: statusReveal 0.35s ease;
         }
 
         .suggest-success-icon {
@@ -827,6 +856,16 @@
         .suggest-success-sub {
             font-size: 0.85rem;
             color: var(--gray-400);
+        }
+
+        @keyframes statusPulse {
+            0%, 100% { opacity: 0.4; }
+            50% { opacity: 1; }
+        }
+
+        @keyframes statusReveal {
+            from { opacity: 0; transform: translateY(4px); }
+            to { opacity: 1; transform: translateY(0); }
         }
 
         /* Minimal variant - just the border animation, no text */
@@ -2271,6 +2310,7 @@
                         <textarea id="suggestReason" name="reason" rows="3" placeholder="What makes this resource valuable..."></textarea>
                     </div>
                     <button type="submit" class="suggest-submit">Send Suggestion <span>→</span></button>
+                    <p class="suggest-status" id="suggestStatus" role="status" aria-live="polite"></p>
                 </form>
             </div>
         </div>
@@ -3892,6 +3932,7 @@
                                 <textarea id="suggestReason" name="reason" rows="3" placeholder="What makes this resource valuable..."></textarea>
                             </div>
                             <button type="submit" class="suggest-submit">Send Suggestion <span>→</span></button>
+                            <p class="suggest-status" id="suggestStatus" role="status" aria-live="polite"></p>
                         </form>
                     `;
                     // Re-attach submit handler
@@ -3906,10 +3947,26 @@
         async function handleSuggestSubmit(e) {
             e.preventDefault();
             const form = e.target;
+            const statusEl = form.querySelector('#suggestStatus');
+            const submitBtn = form.querySelector('.suggest-submit');
             const name = form.querySelector('#suggestName').value.trim();
             const urlRaw = form.querySelector('#suggestUrl').value.trim();
             const category = form.querySelector('#suggestCategory').value.trim();
             const reason = form.querySelector('#suggestReason').value.trim();
+
+            const setStatus = (message, state) => {
+                if (!statusEl) return;
+                statusEl.textContent = message;
+                statusEl.classList.remove('is-sending', 'is-success', 'is-error');
+                if (state) statusEl.classList.add(`is-${state}`);
+            };
+
+            setStatus('Sending...', 'sending');
+            form.setAttribute('aria-busy', 'true');
+            if (submitBtn) {
+                submitBtn.disabled = true;
+                submitBtn.classList.add('is-loading');
+            }
 
             const payload = {
                 name,
@@ -3919,33 +3976,45 @@
                 companyWebsite: ''
             };
 
-            const res = await fetch(`${SUPABASE_URL}/functions/v1/submit-resource`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    apikey: SUPABASE_ANON_KEY,
-                    Authorization: `Bearer ${SUPABASE_ANON_KEY}`
-                },
-                body: JSON.stringify(payload)
-            });
+            try {
+                const res = await fetch(`${SUPABASE_URL}/functions/v1/submit-resource`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        apikey: SUPABASE_ANON_KEY,
+                        Authorization: `Bearer ${SUPABASE_ANON_KEY}`
+                    },
+                    body: JSON.stringify(payload)
+                });
 
-            const data = await res.json().catch(() => ({}));
-            if (!res.ok || !data.ok) {
-                throw new Error(data.error || `Request failed (${res.status})`);
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok || !data.ok) {
+                    throw new Error(data.error || `Request failed (${res.status})`);
+                }
+
+                setStatus('Submitted for review.', 'success');
+
+                // Show success state
+                const formBody = suggestModal.querySelector('.modal-body');
+                formBody.innerHTML = `
+                    <div class="suggest-success" role="status" aria-live="polite">
+                        <div class="suggest-success-icon">+</div>
+                        <p class="suggest-success-text">Thanks! Submitted for review.</p>
+                        <p class="suggest-success-sub">We’ll add it if it’s a good fit.</p>
+                    </div>
+                `;
+
+                // Auto-close after delay
+                setTimeout(closeSuggestModal, 2500);
+            } catch (error) {
+                setStatus(error.message || 'Submission failed. Please try again shortly.', 'error');
+            } finally {
+                form.removeAttribute('aria-busy');
+                if (submitBtn) {
+                    submitBtn.disabled = false;
+                    submitBtn.classList.remove('is-loading');
+                }
             }
-
-            // Show success state
-            const formBody = suggestModal.querySelector('.modal-body');
-            formBody.innerHTML = `
-                <div class="suggest-success">
-                    <div class="suggest-success-icon">+</div>
-                    <p class="suggest-success-text">Thanks! Submitted for review.</p>
-                    <p class="suggest-success-sub">We’ll add it if it’s a good fit.</p>
-                </div>
-            `;
-
-            // Auto-close after delay
-            setTimeout(closeSuggestModal, 2000);
         }
 
         // Suggest modal event handlers


### PR DESCRIPTION
### Motivation
- Form submissions across the site (Callboard, Events, Resources) lacked an obvious completion indicator, so users could be unsure whether their submission succeeded. 
- The Frames & Fabrics event poster referenced the wrong asset and the poster didn’t load. 
- The Plan Your Project page footer duplicated a fixed header/nav element causing a duplicated, non-functional header. 
- The Anthony Brass portfolio section needed a darker, woodier overlay and tighter video card styling to match the intended aesthetic.

### Description
- Added status UI, loading states, and lightweight animations for submission feedback on the events, callboard, and resources forms by extending the existing CSS and wiring JS to toggle `is-loading`/`is-sending`/`is-success`/`is-error` classes and ARIA busy attributes (files touched: `events.html`, `callboard.html`, `resources.html`).
- Updated the Frames & Fabrics poster reference to the existing JPG asset by changing `posterImage` in `events-data.js` to `images/Framesnfabricflyer.JPG`.
- Replaced the duplicated footer nav element in `plan-your-project.html` so it uses a non-navigational `div` wrapper to avoid duplicating the fixed header nav.
- Darkened and adjusted the Anthony Brass overlay and tightened the video container styling (dropped floaty shadow, added brown veil and border) in `portfolio.html`.
- Appended the new change entry to `CHANGELOG_RUNNING.md` documenting the edits and quick verification steps.

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification: Open `events.html`, submit an event via the suggest modal and confirm the status text shows `Sending...` then `Submitted for review.` and the modal auto-closes; verify `images/Framesnfabricflyer.JPG` loads in the Posters area.
- Manual verification: Open `callboard.html`, submit a listing and confirm the status area animates through `Submitting...` to `Submitted for approval.` and the submit button shows a loading state while sending.
- Manual verification: Open `resources.html`, suggest a resource and confirm the suggest button enters a sending state, the status text updates, and the success panel appears before the modal auto-closes.
- Manual verification: Open `plan-your-project.html` and confirm only one header/nav appears and all footer links are clickable.
- Manual verification: Open `portfolio.html` to the Anthony Brass section and confirm the overlay is darker/woodier and the video card has the tightened shadow and subtle border.
- DevTools check: Load `events.html`, `callboard.html`, `resources.html`, `plan-your-project.html`, and `portfolio.html` and verify there are no console errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aab6796cc8327af5e19bf4571d8a4)