### PR TITLE
Remove Events footer CTA and filter Callboard by `approved` flag

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-16 | 10:55PM EST
+———————————————————————
+Change: Removed the Events page footer CTA and aligned footer links; updated callboard query to use approved listings.
+Files touched: events.html, callboard.html, CHANGELOG_RUNNING.md
+Notes:
+1. Events footer now matches the standard footer set without a CTA.
+2. Callboard listings load only rows where approved is true.
+Quick test checklist:
+1. Open events.html → confirm footer shows standard nav links (including Events) and no “Start a Project” button.
+2. Open callboard.html → confirm approved listings render and the status message updates.
+3. Open DevTools console on events.html and callboard.html → confirm no errors.
+
 2026-01-16 | 9:52PM EST
 ———————————————————————
 Change: Prevented footer nav from inheriting fixed header styling to eliminate ghosted headers on portfolio/contact.

--- a/callboard.html
+++ b/callboard.html
@@ -622,7 +622,7 @@
         const fetchListings = async () => {
             setStatus('Loading approved listings...');
             try {
-                const url = `${SUPABASE_CONFIG.url}/rest/v1/callboard_listings?select=id,title,listing_type,compensation,location,description,contact_method,tags,date_posted,created_at&status=eq.approved&order=created_at.desc`;
+                const url = `${SUPABASE_CONFIG.url}/rest/v1/callboard_listings?select=id,title,listing_type,compensation,location,description,contact_method,tags,date_posted,created_at&approved=eq.true&order=created_at.desc`;
                 const response = await fetch(url, {
                     headers: {
                         apikey: SUPABASE_CONFIG.anonKey,

--- a/events.html
+++ b/events.html
@@ -3039,6 +3039,7 @@ END:VCALENDAR`;
             <a href="index.html">Home</a>
             <a href="portfolio.html">Reel</a>
             <a href="resources.html">Resources</a>
+            <a href="events.html">Events</a>
             <a href="ideas.html">Story Generator</a>
             <a href="https://ai.studio/apps/drive/1h-3BvBuLgnF0kRHx43_GWVIlwwWC31od?fullscreenApplet=true" target="_blank" rel="noopener noreferrer">LaB Talk (Beta)</a>
             <a href="contact.html">Contact</a>
@@ -3051,7 +3052,6 @@ END:VCALENDAR`;
                 <img src="images/yt_logo_fullcolor_white_digital.png" alt="YouTube">
             </a>
         </div>
-        <a href="plan-your-project.html" class="footer-cta">Start a Project</a>
         <p class="footer-credit">Made in Shelby Twp, MI with ❤️</p>
     </footer>
 


### PR DESCRIPTION
### Motivation
- Make the Events page footer consistent with other pages by removing the page-specific “Start a Project” CTA. 
- Ensure Callboard listings only surface entries that have been explicitly approved in Supabase by using the boolean `approved` column rather than relying on a non-existent `status` field.

### Description
- Removed the `<a class="footer-cta">Start a Project</a>` element from the footer in `events.html` and added the `Events` link into the footer nav so the footer matches other pages exactly. 
- Updated the Callboard REST query in `callboard.html` to use `approved=eq.true` when fetching listings from Supabase. 
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the change and providing a quick test checklist.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac183b01083279e17e5dd348e41ed)