### PR TITLE
Add Supabase `submit-profile` edge function and setup docs

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,21 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-19 | 3:00AM EST
+———————————————————————
+Change: Added Supabase setup documentation and edge function for directory submissions
+Files touched: SUPABASE_DIRECTORY_SETUP.md, supabase/functions/submit-profile/index.ts, CHANGELOG_RUNNING.md
+Notes:
+1. Documented SQL schema, RLS policy, and deployment steps for directory submissions.
+2. Added submit-profile edge function to insert pending listings and ignore honeypot spam.
+Quick test checklist:
+1. Open directory.html → Join the Directory and submit a profile (required fields only)
+2. In Supabase, confirm a new row appears in directory_listings with status = pending
+3. Mark the row approved and refresh directory.html to see the card appear
+4. Check DevTools Console for errors on directory.html
+
+
+
 2026-01-18 | 9:25PM EST
 ———————————————————————
 Change: Restyled directory submission form with dark theme and success animation

--- a/SUPABASE_DIRECTORY_SETUP.md
+++ b/SUPABASE_DIRECTORY_SETUP.md
@@ -1,0 +1,63 @@
+# Supabase Directory Setup (submit-profile)
+
+This repo’s `directory.html` form posts to the `submit-profile` edge function. Use the steps below to create the table, policies, and function so submissions succeed and approved profiles render on the page.
+
+## 1) Create table + policies
+
+Run this in the Supabase SQL editor:
+
+```sql
+create table if not exists public.directory_listings (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  role text not null,
+  location text not null,
+  email text not null,
+  bio text,
+  roles_worked text,
+  past_work text,
+  website text,
+  instagram text,
+  imdb text,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected')),
+  created_at timestamptz not null default now()
+);
+
+alter table public.directory_listings enable row level security;
+
+create policy "directory_public_read"
+  on public.directory_listings
+  for select
+  using (status = 'approved');
+```
+
+## 2) Add the edge function
+
+Create a new edge function named `submit-profile` and use the code in:
+
+```
+supabase/functions/submit-profile/index.ts
+```
+
+### Required environment variables
+
+Set these in Supabase (Edge Functions → Settings → Environment variables):
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+## 3) Deploy
+
+From your local Supabase CLI:
+
+```bash
+supabase functions deploy submit-profile
+```
+
+## 4) Verify from the site
+
+1. Open `directory.html` → “Join the Directory”.
+2. Submit a new profile with valid required fields.
+3. Confirm a new row appears in `directory_listings` with `status = 'pending'`.
+4. Manually set the row to `approved` to see it appear on the directory page.
+```

--- a/supabase/functions/submit-profile/index.ts
+++ b/supabase/functions/submit-profile/index.ts
@@ -1,0 +1,84 @@
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const required = ["name", "role", "location", "email"];
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const payload = await req.json();
+
+    if (payload?.honeypot_field) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const missing = required.filter((field) => !payload?.[field]);
+    if (missing.length) {
+      return new Response(JSON.stringify({ error: "Missing required fields", missing }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return new Response(JSON.stringify({ error: "Server misconfigured" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const { error } = await supabase.from("directory_listings").insert({
+      name: String(payload.name).trim(),
+      role: String(payload.role).trim(),
+      location: String(payload.location).trim(),
+      email: String(payload.email).trim(),
+      bio: payload.bio ? String(payload.bio).trim() : null,
+      roles_worked: payload.roles_worked ? String(payload.roles_worked).trim() : null,
+      past_work: payload.past_work ? String(payload.past_work).trim() : null,
+      website: payload.website ? String(payload.website).trim() : null,
+      instagram: payload.instagram ? String(payload.instagram).trim() : null,
+      imdb: payload.imdb ? String(payload.imdb).trim() : null,
+      status: "pending",
+    });
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (_error) {
+    return new Response(JSON.stringify({ error: "Invalid request" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
### Motivation
- The directory submission form in `directory.html` had no server-side endpoint, so submissions failed when the `submit-profile` edge function and table were not present.
- Provide a minimal, zero-cost Supabase-backed flow that accepts profile submissions, prevents spam via a honeypot, and marks new rows `pending` for moderation.

### Description
- Added an edge function implementation at `supabase/functions/submit-profile/index.ts` that validates required fields, ignores honeypot spam, inserts a `pending` row into `directory_listings`, and returns CORS-friendly responses.
- Added `SUPABASE_DIRECTORY_SETUP.md` with the recommended SQL schema, row-level security policy, environment variables, and deployment steps for `submit-profile`.
- Appended a changelog entry to `CHANGELOG_RUNNING.md` documenting the setup and quick verification checklist.
- Files touched: `supabase/functions/submit-profile/index.ts`, `SUPABASE_DIRECTORY_SETUP.md`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d9df3dc0c8327bd3538835e0ce2d7)