### PR TITLE
Align callboard submission modal with directory styling

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,34 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-18 | 10:56PM EST
+———————————————————————
+Change: Matched callboard submission modal styling to directory form layout
+Files touched: callboard.html, CHANGELOG_RUNNING.md
+Notes:
+1. Restructured the submission modal with header/body/footer sections and form-group layout.
+2. Applied dark input styling, custom selects, and optional tag labels to remove white fields.
+3. Tuned modal spacing to align with the directory form presentation.
+Quick test checklist:
+1. Open callboard.html → click "Submit a Listing" and confirm dark inputs/selects match the directory style.
+2. Verify form rows align neatly on desktop and stack cleanly on smaller screens.
+3. Submit the form (use test values) and confirm success highlight animation still appears.
+4. Open DevTools Console on callboard.html and confirm no errors.
+
+2026-01-18 | 10:50PM EST
+———————————————————————
+Change: Restyled callboard submission form and added success animation polish
+Files touched: callboard.html, CHANGELOG_RUNNING.md
+Notes:
+1. Unified form layout with grid-based rows, uppercase labels, and consistent spacing.
+2. Added clean focus states and helper text styling to match site aesthetic.
+3. Added a success animation that highlights the modal on completed submission.
+Quick test checklist:
+1. Open callboard.html → click "Submit a Listing" and confirm the modal layout/labels align with site style.
+2. Submit the form (use test values) and confirm success message + modal success animation appears before auto-close.
+3. Reopen the modal and confirm the success styling resets.
+4. Open DevTools Console on callboard.html and confirm no errors.
+
 2026-01-19 | 3:00AM EST
 ———————————————————————
 Change: Added Supabase setup documentation and edge function for directory submissions

--- a/callboard.html
+++ b/callboard.html
@@ -704,11 +704,11 @@
         .modal {
             position: fixed;
             inset: 0;
-            background: rgba(0, 0, 0, 0.8);
+            background: rgba(0, 0, 0, 0.9);
             display: none;
             align-items: center;
             justify-content: center;
-            padding: 2rem;
+            padding: 1.5rem;
             z-index: 2000;
         }
 
@@ -717,55 +717,164 @@
         }
 
         .modal-content {
-            background: var(--black);
+            background: var(--gray-900);
             border: 1px solid var(--gray-800);
-            padding: 2rem;
-            width: min(640px, 100%);
+            padding: 0;
+            width: min(620px, 100%);
             max-height: 90vh;
             overflow-y: auto;
+            position: relative;
+            transition: border-color 0.3s ease;
         }
 
-        .modal-content h2 {
+        .modal-content.is-success {
+            border-color: var(--lab-green);
+            animation: formSuccess 0.6s ease;
+        }
+
+        .modal-content::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 2px;
+            width: 0;
+            background: var(--lab-green);
+        }
+
+        .modal-content.is-success::after {
+            animation: successLine 0.6s ease forwards;
+        }
+
+        .modal-header {
+            padding: 1.5rem 2rem;
+            border-bottom: 1px solid var(--gray-800);
+        }
+
+        .modal-header h2 {
             font-family: 'Space Mono', monospace;
             color: var(--white);
-            font-size: 1.4rem;
-            margin-bottom: 1rem;
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+            letter-spacing: 1px;
+        }
+
+        .modal-header p {
+            color: var(--gray-400);
+            margin: 0;
+            font-size: 0.85rem;
+        }
+
+        .modal-body {
+            padding: 1.5rem 2rem;
         }
 
         .modal-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .form-row {
             display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             gap: 1rem;
         }
 
-        .modal-form label {
-            font-size: 0.8rem;
-            color: var(--white);
+        .form-label {
+            font-size: 0.7rem;
+            color: var(--gray-400);
             display: block;
-            margin-bottom: 0.3rem;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-family: 'Space Mono', monospace;
+        }
+
+        .form-label .optional-tag {
+            font-size: 0.6rem;
+            color: var(--gray-600);
+            text-transform: none;
+            letter-spacing: 0;
+            margin-left: 0.5rem;
         }
 
         .modal-form input,
         .modal-form select,
         .modal-form textarea {
             width: 100%;
-            background: transparent;
-            border: 1px solid var(--gray-600);
+            background: var(--black);
+            border: 1px solid var(--gray-800);
             color: var(--white);
-            padding: 0.6rem 0.8rem;
-            font-size: 0.85rem;
+            padding: 0.85rem 1rem;
+            font-size: 0.9rem;
+            font-family: 'Inter', sans-serif;
+            transition: all 0.2s ease;
+            color-scheme: dark;
+        }
+
+        .modal-form input::placeholder,
+        .modal-form textarea::placeholder {
+            color: var(--gray-600);
+        }
+
+        .modal-form input:focus,
+        .modal-form select:focus,
+        .modal-form textarea:focus {
+            outline: none;
+            border-color: var(--gray-600);
+            background: rgba(255, 255, 255, 0.02);
         }
 
         .modal-form textarea {
             min-height: 120px;
             resize: vertical;
+            line-height: 1.5;
         }
 
-        .modal-actions {
+        .modal-form select {
+            cursor: pointer;
+            appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23888888' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10l-5 5z'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 1rem center;
+        }
+
+        .modal-form select option {
+            background: var(--black);
+            color: var(--white);
+            padding: 0.5rem;
+        }
+
+        .modal-form input[type="date"]::-webkit-calendar-picker-indicator {
+            filter: invert(0.7);
+        }
+
+        .form-hint,
+        .modal-form .help-text {
+            font-size: 0.7rem;
+            color: var(--gray-600);
+            margin-top: 0.25rem;
+        }
+
+        .modal-footer {
+            padding: 1.25rem 2rem;
+            border-top: 1px solid var(--gray-800);
             display: flex;
             justify-content: space-between;
             gap: 1rem;
             flex-wrap: wrap;
-            margin-top: 0.5rem;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 0.75rem;
+            margin-left: auto;
         }
 
         .secondary-btn {
@@ -786,6 +895,30 @@
             width: 1px;
             height: 1px;
             overflow: hidden;
+        }
+
+        @keyframes successLine {
+            from {
+                width: 0;
+            }
+
+            to {
+                width: 100%;
+            }
+        }
+
+        @keyframes formSuccess {
+            0% {
+                transform: scale(0.98);
+            }
+
+            60% {
+                transform: scale(1.01);
+            }
+
+            100% {
+                transform: scale(1);
+            }
         }
 
         @media (max-width: 768px) {
@@ -1009,77 +1142,82 @@
 
     <div class="modal" id="modal" aria-hidden="true" role="dialog" aria-labelledby="modalTitle">
         <div class="modal-content">
-            <h2 id="modalTitle">Submit a Listing</h2>
-            <p>Listings are reviewed within 24 hours.</p>
-            <form id="listingForm">
-                <div>
-                    <label for="title">Project Title</label>
+            <div class="modal-header">
+                <h2 id="modalTitle">Submit a Listing</h2>
+                <p>Listings are reviewed within 24 hours.</p>
+            </div>
+            <form id="listingForm" class="modal-form">
+                <div class="modal-body">
+                <div class="form-group">
+                    <label class="form-label" for="title">Project Title</label>
                     <input id="title" name="title" required maxlength="60">
                 </div>
                 <div class="form-row">
-                    <div>
-                        <label for="listingType">Type</label>
+                    <div class="form-group">
+                        <label class="form-label" for="listingType">Type</label>
                         <select id="listingType" name="listing_type">
                             <option value="crew">Crew Call</option>
                             <option value="casting">Casting Call</option>
                         </select>
                     </div>
-                    <div>
-                        <label for="compensation">Compensation</label>
+                    <div class="form-group">
+                        <label class="form-label" for="compensation">Compensation</label>
                         <select id="compensation" name="compensation">
                             <option value="paid">Paid</option>
                             <option value="collab">TFP / Collab</option>
                         </select>
                     </div>
                 </div>
-                <div>
-                    <label for="location">Location (City, State)</label>
+                <div class="form-group">
+                    <label class="form-label" for="location">Location (City, State)</label>
                     <input id="location" name="location" required maxlength="40" placeholder="e.g. Detroit, MI">
                 </div>
 
                 <!-- New Date Fields API -->
                 <div class="form-row">
-                    <div>
-                        <label for="optionsOpen">Options Open (opt)</label>
+                    <div class="form-group">
+                        <label class="form-label" for="optionsOpen">Options Open <span class="optional-tag">(opt)</span></label>
                         <input id="optionsOpen" name="options_opening" type="date">
                     </div>
-                    <div>
-                        <label for="optionsClose">Options Close (opt)</label>
+                    <div class="form-group">
+                        <label class="form-label" for="optionsClose">Options Close <span class="optional-tag">(opt)</span></label>
                         <input id="optionsClose" name="options_closing" type="date">
                     </div>
                 </div>
-                <div>
-                    <label for="shootingDates">Shooting Dates (optional)</label>
+                <div class="form-group">
+                    <label class="form-label" for="shootingDates">Shooting Dates <span class="optional-tag">(optional)</span></label>
                     <input id="shootingDates" name="shooting_dates" placeholder="e.g. Oct 12-14" maxlength="50">
                 </div>
 
-                <div>
-                    <label for="description">Description & Requirements</label>
+                <div class="form-group">
+                    <label class="form-label" for="description">Description & Requirements</label>
                     <textarea id="description" name="description" rows="5" required></textarea>
                 </div>
-                <div>
-                    <label for="contactMethod">Contact Link or Email</label>
+                <div class="form-group">
+                    <label class="form-label" for="contactMethod">Contact Link or Email</label>
                     <input id="contactMethod" name="contact_method" required
                         placeholder="https://... or email@example.com">
                 </div>
-                <div>
-                    <label for="tags">Tags (comma separated)</label>
+                <div class="form-group">
+                    <label class="form-label" for="tags">Tags <span class="optional-tag">(comma separated)</span></label>
                     <input id="tags" name="tags" maxlength="200">
                 </div>
-                <div>
-                    <label for="expiresOn">Listing Expires On (optional)</label>
+                <div class="form-group">
+                    <label class="form-label" for="expiresOn">Listing Expires On <span class="optional-tag">(optional)</span></label>
                     <input id="expiresOn" name="expires_on" type="date">
-                    <p style="font-size:0.65rem; color:var(--gray-600); margin-top:0.25rem;">Listing will automatically
-                        move to "Expired" after this date.</p>
+                    <p class="help-text">Listing will automatically move to "Expired" after this date.</p>
                 </div>
                 <div class="hidden-honeypot" aria-hidden="true">
-                    <label for="companyWebsite">Company Website</label>
+                    <label class="form-label" for="companyWebsite">Company Website</label>
                     <input id="companyWebsite" name="companyWebsite" autocomplete="off" tabindex="-1">
                 </div>
-                <div class="status-message" id="formStatus">All submissions are reviewed before publishing.</div>
-                <div class="modal-actions">
-                    <button type="button" class="secondary-btn" id="closeModal">Close</button>
-                    <button type="submit" class="submit-btn">Send for Review</button>
+                </div>
+                <div class="modal-footer">
+                    <div class="status-message" id="formStatus">All submissions are reviewed before publishing.</div>
+                    <div class="modal-actions">
+                        <button type="button" class="secondary-btn" id="closeModal">Close</button>
+                        <button type="submit" class="submit-btn">Send for Review</button>
+                    </div>
                 </div>
             </form>
         </div>
@@ -1113,6 +1251,7 @@
         const closeModal = document.getElementById('closeModal');
         const listingForm = document.getElementById('listingForm');
         const formStatus = document.getElementById('formStatus');
+        const modalContent = modal.querySelector('.modal-content');
 
         // Detail Modal Elements
         const detailModal = document.getElementById('detailModal');
@@ -1419,6 +1558,7 @@
         const openModalView = () => {
             modal.classList.add('active');
             modal.setAttribute('aria-hidden', 'false');
+            if (modalContent) modalContent.classList.remove('is-success');
             const firstField = modal.querySelector('input, select, textarea, button');
             if (firstField) firstField.focus();
             document.body.style.overflow = 'hidden';
@@ -1431,6 +1571,7 @@
             modal.classList.remove('active');
             modal.setAttribute('aria-hidden', 'true');
             document.body.style.overflow = '';
+            if (modalContent) modalContent.classList.remove('is-success');
         };
 
         openModal.addEventListener('click', openModalView);
@@ -1500,6 +1641,7 @@
                 }
 
                 setFormStatus('Submitted for approval!', 'success');
+                if (modalContent) modalContent.classList.add('is-success');
                 listingForm.reset();
 
                 // Auto-close modal after showing success


### PR DESCRIPTION
### Motivation
- Make the Callboard submission modal visually match the already-styled Directory form by removing the white inputs and improving spacing, typography, and focus states.  
- Preserve and slightly refine the existing success affordance so users receive clear feedback after a submission.  

### Description
- Restyled the modal and form in `callboard.html` including overlay darkness, `.modal-content` background, padding and width adjustments, and added `modal-header`, `modal-body`, and `modal-footer` sections.  
- Introduced form layout primitives: `.modal-form`/`.form-group`, `.form-row`, `.form-label` and `.optional-tag`, plus dark input/select/textarea styling, custom select arrow, date-picker indicator styling, and helper text via `.help-text`.  
- Added a success visual treatment by wiring `modalContent` and toggling `.is-success` on submit, plus `successLine` / `formSuccess` keyframes and a 2px success line animation.  
- Updated JS to cache `modalContent`, remove success state when opening/closing the modal, keep existing submission flow (reset form, update `status-message`), and updated `CHANGELOG_RUNNING.md` with the change entry.  

### Testing
- Started a local static server with `python -m http.server` and ran a Playwright script to load `http://127.0.0.1:8000/callboard.html` and capture a full-page screenshot (`artifacts/callboard-page.png`), which succeeded.  
- Playwright attempts to programmatically click `#openModal` timed out in some runs, so the modal open and success animation were not fully validated by the automation.  
- No unit or integration test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da9af1110832791bcfe7015637354)