### PR TITLE
Improve callboard submission error handling

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-19 | 4:17AM EST
+———————————————————————
+Change: Improved callboard submission error handling and honeypot feedback
+Files touched: callboard.html, CHANGELOG_RUNNING.md
+Notes:
+1. Added early honeypot detection to avoid false failures from autofill.
+2. Surfaced server error details and rate-limit messaging to users.
+Quick test checklist:
+1. Open callboard.html → submit with the hidden honeypot filled and confirm a spam/autofill warning appears.
+2. Submit with valid fields and confirm success message appears and the modal auto-closes.
+3. Open DevTools Console on callboard.html and confirm no errors.
+
 2026-01-18 | 10:50PM EST
 ———————————————————————
 Change: Restyled callboard submission form and added success animation polish

--- a/callboard.html
+++ b/callboard.html
@@ -1623,6 +1623,16 @@
                 honeypot_field: listingForm.companyWebsite.value.trim()
             };
 
+            if (payload.honeypot_field) {
+                setFormStatus('Submission blocked. Please disable autofill for hidden fields and try again.', 'error');
+                listingForm.removeAttribute('aria-busy');
+                if (submitBtn) {
+                    submitBtn.disabled = false;
+                    submitBtn.classList.remove('is-loading');
+                }
+                return;
+            }
+
             try {
                 const response = await fetch(`${SUPABASE_CONFIG.url}/functions/v1/submit-listing`, {
                     method: 'POST',
@@ -1635,7 +1645,22 @@
                 });
 
                 if (!response.ok) {
-                    throw new Error('Request failed');
+                    let errorMessage = 'Something went wrong. Please try again in a moment.';
+                    try {
+                        const errorBody = await response.json();
+                        if (errorBody && errorBody.message) {
+                            errorMessage = errorBody.message;
+                        }
+                    } catch (parseError) {
+                        const errorText = await response.text();
+                        if (errorText) {
+                            errorMessage = errorText;
+                        }
+                    }
+                    if (response.status === 429) {
+                        errorMessage = 'Too many submissions in a short time. Please wait a minute and try again.';
+                    }
+                    throw new Error(errorMessage);
                 }
 
                 setFormStatus('Submitted for approval!', 'success');
@@ -1651,7 +1676,7 @@
                     }, 300);
                 }, 2000);
             } catch (error) {
-                setFormStatus('Something went wrong. Please try again in a moment.', 'error');
+                setFormStatus(error.message || 'Something went wrong. Please try again in a moment.', 'error');
             } finally {
                 listingForm.removeAttribute('aria-busy');
                 if (submitBtn) {


### PR DESCRIPTION
### Motivation
- Users were seeing opaque "Something went wrong" failures when submitting to the callboard, likely caused by hidden honeypot autofill or unhelpful server errors, so client-side handling and messaging needed to be clearer.

### Description
- Added early honeypot detection in `callboard.html` to block submissions when the hidden `companyWebsite` field is populated and show a clear autofill/spam warning to the user.
- Enhanced submission error handling in `callboard.html` to parse and surface server-provided error messages and to show a specific message when `429` rate-limit responses are returned.
- Ensured the UI always cleans up state (removes `aria-busy`, re-enables the submit button, and clears loading classes) on success or error, and documented the change in `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db016ea7c8327ab88e2fa8d378627)