### PR TITLE
Remove callboard option dates and make directory location free-text

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,19 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-19 | 5:09AM EST
+———————————————————————
+Change: Removed callboard option dates and made directory location free text
+Files touched: callboard.html, directory.html, CHANGELOG_RUNNING.md
+Notes:
+1. Removed Options Open/Close fields from the callboard submission form and payload.
+2. Swapped directory location dropdown for a free-text input while keeping location filters usable.
+Quick test checklist:
+1. Open callboard.html → open the submission modal and confirm Options Open/Close fields are gone.
+2. Open directory.html → open Join Directory and confirm Base Location is a text field; submit and verify success.
+3. Filter directory listings by location buttons and confirm results still match text locations.
+4. Open DevTools Console on callboard.html and directory.html and confirm no errors.
+
 2026-01-19 | 4:17AM EST
 ———————————————————————
 Change: Improved callboard submission error handling and honeypot feedback

--- a/callboard.html
+++ b/callboard.html
@@ -1171,17 +1171,6 @@
                     <input id="location" name="location" required maxlength="40" placeholder="e.g. Detroit, MI">
                 </div>
 
-                <!-- New Date Fields API -->
-                <div class="form-row">
-                    <div class="form-group">
-                        <label class="form-label" for="optionsOpen">Options Open <span class="optional-tag">(opt)</span></label>
-                        <input id="optionsOpen" name="options_opening" type="date">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="optionsClose">Options Close <span class="optional-tag">(opt)</span></label>
-                        <input id="optionsClose" name="options_closing" type="date">
-                    </div>
-                </div>
                 <div class="form-group">
                     <label class="form-label" for="shootingDates">Shooting Dates <span class="optional-tag">(optional)</span></label>
                     <input id="shootingDates" name="shooting_dates" placeholder="e.g. Oct 12-14" maxlength="50">
@@ -1615,9 +1604,6 @@
                 contact_method: listingForm.contact_method.value.trim(),
                 tags: listingForm.tags.value.trim(),
                 expires_on: listingForm.expires_on.value || null,
-                // New Fields
-                options_opening: listingForm.options_opening.value || null,
-                options_closing: listingForm.options_closing.value || null,
                 shooting_dates: listingForm.shooting_dates.value.trim() || null,
 
                 honeypot_field: listingForm.companyWebsite.value.trim()

--- a/directory.html
+++ b/directory.html
@@ -1292,16 +1292,7 @@
                         </div>
                         <div class="form-group">
                             <label for="location" class="form-label">Base Location</label>
-                            <select id="location" name="location" required>
-                                <option value="detroit">Metro Detroit</option>
-                                <option value="grand-rapids">Grand Rapids</option>
-                                <option value="lansing">Lansing</option>
-                                <option value="ann-arbor">Ann Arbor</option>
-                                <option value="traverse-city">Traverse City</option>
-                                <option value="flint">Flint / Saginaw</option>
-                                <option value="kalamazoo">Kalamazoo</option>
-                                <option value="remote">Remote / Any</option>
-                            </select>
+                            <input id="location" name="location" required maxlength="60" placeholder="e.g. Detroit, MI">
                         </div>
                     </div>
 
@@ -1434,8 +1425,11 @@
 
                 // Filter Location
                 // "All MI" (all) vs specific city.
-                // The form is a Select, so single value.
-                if (state.filterArea !== 'all' && item.location !== state.filterArea) return false;
+                const normalizedLocation = normalizeText(item.location).replace(/-/g, ' ');
+                if (state.filterArea !== 'all') {
+                    const normalizedArea = normalizeText(state.filterArea).replace(/-/g, ' ');
+                    if (!normalizedLocation || !normalizedLocation.includes(normalizedArea)) return false;
+                }
 
                 // Search
                 if (searchTerm) {


### PR DESCRIPTION
### Motivation
- Remove the rarely-used Options Open/Close date fields from the callboard submission flow to simplify the form and payload.
- Replace the directory location dropdown with a free-text field so users can enter arbitrary city/state values while keeping client-side filters working.

### Description
- Removed the Options Open/Options Close inputs from the callboard submission form HTML and removed those properties from the submission payload handling in `callboard.html`.
- Kept `shooting_dates` and existing honeypot logic intact so submission flow and spam protection are unchanged in `callboard.html`.
- Replaced the `location` select with a free-text `input` in `directory.html` and updated the directory filtering logic to normalize and substring-match free-text locations against the existing location filter buttons.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the changes and manual test checklist.

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification checklist: Open `callboard.html` and confirm the Options Open/Close fields are not present in the submission modal.
- Manual verification checklist: Open `directory.html`, open the Join Directory modal and confirm Base Location is a free-text field and profile submission follows the normal success flow.
- Manual verification checklist: Use the directory location filter buttons and confirm they still match profiles whose `location` text contains the button value, and check DevTools Console on both pages for no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dbc1862c08327be156edd830e5b93)