### PR TITLE
Prevent enter submits and show Posted/Expires dates

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,32 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-19 | 5:19AM EST
+———————————————————————
+Change: Prevented enter-key form submits and clarified callboard dates
+Files touched: callboard.html, directory.html, CHANGELOG_RUNNING.md
+Notes:
+1. Added enter-key guards to prevent accidental submits while typing in inputs.
+2. Updated callboard listing cards to show Posted and Expires dates separately.
+Quick test checklist:
+1. Open callboard.html → focus an input and press Enter; confirm the form does not submit.
+2. Open directory.html → focus an input and press Enter; confirm the form does not submit.
+3. Verify callboard listings display Posted and Expires dates in the meta row.
+4. Open DevTools Console on callboard.html and directory.html and confirm no errors.
+
+2026-01-19 | 5:09AM EST
+———————————————————————
+Change: Removed callboard option dates and made directory location free text
+Files touched: callboard.html, directory.html, CHANGELOG_RUNNING.md
+Notes:
+1. Removed Options Open/Close fields from the callboard submission form and payload.
+2. Swapped directory location dropdown for a free-text input while keeping location filters usable.
+Quick test checklist:
+1. Open callboard.html → open the submission modal and confirm Options Open/Close fields are gone.
+2. Open directory.html → open Join Directory and confirm Base Location is a text field; submit and verify success.
+3. Filter directory listings by location buttons and confirm results still match text locations.
+4. Open DevTools Console on callboard.html and directory.html and confirm no errors.
+
 2026-01-19 | 4:17AM EST
 ———————————————————————
 Change: Improved callboard submission error handling and honeypot feedback

--- a/callboard.html
+++ b/callboard.html
@@ -1171,17 +1171,6 @@
                     <input id="location" name="location" required maxlength="40" placeholder="e.g. Detroit, MI">
                 </div>
 
-                <!-- New Date Fields API -->
-                <div class="form-row">
-                    <div class="form-group">
-                        <label class="form-label" for="optionsOpen">Options Open <span class="optional-tag">(opt)</span></label>
-                        <input id="optionsOpen" name="options_opening" type="date">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="optionsClose">Options Close <span class="optional-tag">(opt)</span></label>
-                        <input id="optionsClose" name="options_closing" type="date">
-                    </div>
-                </div>
                 <div class="form-group">
                     <label class="form-label" for="shootingDates">Shooting Dates <span class="optional-tag">(optional)</span></label>
                     <input id="shootingDates" name="shooting_dates" placeholder="e.g. Oct 12-14" maxlength="50">
@@ -1311,7 +1300,8 @@
             }
 
             listingsEl.innerHTML = filtered.map((listing) => {
-                const dateLabel = formatDate(listing.date_posted || listing.created_at);
+                const postedLabel = formatDate(listing.date_posted || listing.created_at);
+                const expiresLabel = formatDate(listing.expires_on);
                 // Compact Card: No description, no tags, no contact link visible inline
                 return `
                     <article class="listing-card" data-id="${listing.id}">
@@ -1322,7 +1312,8 @@
                             <span
                                 class="badge ${listing.compensation === 'paid' ? 'badge-paid' : 'badge-collab'}">${listing.compensation}</span>
                             <span class="location">${listing.location}</span>
-                            ${dateLabel ? `<span class="date">${dateLabel}</span>` : ''}
+                            ${postedLabel ? `<span class="date">Posted: ${postedLabel}</span>` : ''}
+                            ${expiresLabel ? `<span class="date">Expires: ${expiresLabel}</span>` : ''}
                         </div>
                     </article>
                 `;
@@ -1352,7 +1343,8 @@
             }
 
             pastListingsEl.innerHTML = filledListings.map((listing) => {
-                const dateLabel = formatDate(listing.date_posted || listing.created_at);
+                const postedLabel = formatDate(listing.date_posted || listing.created_at);
+                const expiresLabel = formatDate(listing.expires_on);
                 const expired = isExpired(listing);
                 const badgeText = listing.status === 'filled' ? 'Filled' : (expired ? 'Expired' : 'Ended');
 
@@ -1362,7 +1354,8 @@
                         <div class="listing-meta">
                             <span class="badge badge-filled">${badgeText}</span>
                             <span class="location">${listing.location}</span>
-                            ${dateLabel ? `<span class="date">${dateLabel}</span>` : ''}
+                            ${postedLabel ? `<span class="date">Posted: ${postedLabel}</span>` : ''}
+                            ${expiresLabel ? `<span class="date">Expires: ${expiresLabel}</span>` : ''}
                         </div>
                     </article>
                 `;
@@ -1596,6 +1589,17 @@
             if (state) formStatus.classList.add(`is-${state}`);
         };
 
+        listingForm.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter') return;
+            const target = event.target;
+            const tag = target.tagName.toLowerCase();
+            const isTextarea = tag === 'textarea';
+            const isSubmitButton = tag === 'button' && target.type === 'submit';
+            if (!isTextarea && !isSubmitButton) {
+                event.preventDefault();
+            }
+        });
+
         listingForm.addEventListener('submit', async (event) => {
             event.preventDefault();
             const submitBtn = listingForm.querySelector('button[type="submit"]');
@@ -1615,9 +1619,6 @@
                 contact_method: listingForm.contact_method.value.trim(),
                 tags: listingForm.tags.value.trim(),
                 expires_on: listingForm.expires_on.value || null,
-                // New Fields
-                options_opening: listingForm.options_opening.value || null,
-                options_closing: listingForm.options_closing.value || null,
                 shooting_dates: listingForm.shooting_dates.value.trim() || null,
 
                 honeypot_field: listingForm.companyWebsite.value.trim()

--- a/directory.html
+++ b/directory.html
@@ -1292,16 +1292,7 @@
                         </div>
                         <div class="form-group">
                             <label for="location" class="form-label">Base Location</label>
-                            <select id="location" name="location" required>
-                                <option value="detroit">Metro Detroit</option>
-                                <option value="grand-rapids">Grand Rapids</option>
-                                <option value="lansing">Lansing</option>
-                                <option value="ann-arbor">Ann Arbor</option>
-                                <option value="traverse-city">Traverse City</option>
-                                <option value="flint">Flint / Saginaw</option>
-                                <option value="kalamazoo">Kalamazoo</option>
-                                <option value="remote">Remote / Any</option>
-                            </select>
+                            <input id="location" name="location" required maxlength="60" placeholder="e.g. Detroit, MI">
                         </div>
                     </div>
 
@@ -1424,6 +1415,17 @@
 
         const normalizeText = (text) => (text || '').toLowerCase();
 
+        listingForm.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter') return;
+            const target = event.target;
+            const tag = target.tagName.toLowerCase();
+            const isTextarea = tag === 'textarea';
+            const isSubmitButton = tag === 'button' && target.type === 'submit';
+            if (!isTextarea && !isSubmitButton) {
+                event.preventDefault();
+            }
+        });
+
         // Render Profiles
         const renderListings = () => {
             const searchTerm = normalizeText(state.search);
@@ -1434,8 +1436,11 @@
 
                 // Filter Location
                 // "All MI" (all) vs specific city.
-                // The form is a Select, so single value.
-                if (state.filterArea !== 'all' && item.location !== state.filterArea) return false;
+                const normalizedLocation = normalizeText(item.location).replace(/-/g, ' ');
+                if (state.filterArea !== 'all') {
+                    const normalizedArea = normalizeText(state.filterArea).replace(/-/g, ' ');
+                    if (!normalizedLocation || !normalizedLocation.includes(normalizedArea)) return false;
+                }
 
                 // Search
                 if (searchTerm) {


### PR DESCRIPTION
### Motivation
- Prevent accidental form submissions when users press Enter while filling inputs in modals to improve UX and avoid lost work.
- Clarify listing metadata by showing separate Posted and Expires dates in callboard cards so dates are unambiguous.
- Keep prior simplifications (removed Options Open/Close and allow free-text directory locations) consistent with the UI changes.

### Description
- Added an `keydown` handler on `listingForm` in `callboard.html` and `directory.html` to `preventDefault()` for Enter presses unless the target is a `textarea` or a submit `button` so Enter no longer submits forms accidentally.
- Updated callboard rendering code in `callboard.html` to compute `postedLabel` and `expiresLabel` via `formatDate(...)` and render `Posted: <date>` and `Expires: <date>` in the listing meta row for both active and past listings.
- Removed the `options_opening`/`options_closing` submission fields from the form payload and kept `shooting_dates`/`expires_on` handling intact, and replaced the directory location `select` with a free-text `input` while normalizing substring matching in the directory filters.
- Appended an entry to `CHANGELOG_RUNNING.md` documenting the changes and a quick manual test checklist.

### Testing
- Automated tests: none were run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dbc1862c08327be156edd830e5b93)