### PR TITLE
Reorder Community nav dropdown links

### DIFF
--- a/404.html
+++ b/404.html
@@ -368,9 +368,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-19 | 6:28AM EST
+———————————————————————
+Change: Reordered the Community nav dropdown to list Callboard, Directory, then Events.
+Files touched: 404.html, callboard.html, contact.html, directory.html, events.html, ideas.html, index.html, past-events.html, plan-your-project.html, portfolio.html, resources.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open any page → Community dropdown shows Callboard, Directory, Events in that order.
+2. Repeat on events.html to confirm mobile nav dropdown order matches.
+3. Open DevTools Console on index.html and confirm no errors.
+
 2026-01-19 | 1:07AM EST
 ———————————————————————
 Change: Refined resources listings, references subfilters, and community labels to match updated curation.

--- a/callboard.html
+++ b/callboard.html
@@ -1027,9 +1027,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/contact.html
+++ b/contact.html
@@ -784,9 +784,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/directory.html
+++ b/directory.html
@@ -1151,9 +1151,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/events.html
+++ b/events.html
@@ -2184,9 +2184,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/ideas.html
+++ b/ideas.html
@@ -1856,10 +1856,10 @@
                         </svg>
                     </button>
                     <div class="nav-dropdown-menu">
-                        <a href="events.html">Events</a>
                         <a href="callboard.html">Callboard</a>
-                        <a href="directory.html">Directory</a>
-                    </div>
+                    <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
+                </div>
                 </li>
                 <li class="nav-dropdown">
                     <button class="nav-dropdown-toggle" aria-expanded="false" aria-haspopup="true">

--- a/index.html
+++ b/index.html
@@ -2102,9 +2102,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/past-events.html
+++ b/past-events.html
@@ -573,9 +573,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/plan-your-project.html
+++ b/plan-your-project.html
@@ -1314,9 +1314,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/portfolio.html
+++ b/portfolio.html
@@ -2028,9 +2028,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">

--- a/resources.html
+++ b/resources.html
@@ -2873,9 +2873,9 @@
                     </svg>
                 </button>
                 <div class="nav-dropdown-menu">
-                    <a href="events.html">Events</a>
                     <a href="callboard.html">Callboard</a>
                     <a href="directory.html">Directory</a>
+                    <a href="events.html">Events</a>
                 </div>
             </li>
             <li class="nav-dropdown">


### PR DESCRIPTION
### Motivation
- Make the top-level "Community" nav consistent and surface the Callboard first, followed by Directory then Events, because Events was appearing first across pages. 
- Apply the change everywhere the site shell appears so desktop and mobile menus match and navigation order is predictable.

### Description
- Reordered the `<div class="nav-dropdown-menu">` links to `Callboard`, `Directory`, `Events` across site templates in `404.html`, `callboard.html`, `contact.html`, `directory.html`, `events.html`, `ideas.html`, `index.html`, `past-events.html`, `plan-your-project.html`, `portfolio.html`, and `resources.html`.
- Added a new entry at the top of `CHANGELOG_RUNNING.md` documenting the nav reorder and a quick test checklist.
- Kept all existing attributes and markup intact to avoid introducing regressions in the menu toggle or accessibility attributes.

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification: Open any page and confirm the Community dropdown displays `Callboard`, `Directory`, `Events` in that order.
- Manual verification: Open `events.html` at a mobile-width viewport and confirm the Community dropdown order matches the desktop order.
- Manual verification: Open DevTools Console on `index.html` and confirm there are no new errors and that `CHANGELOG_RUNNING.md` contains the new entry at the top.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dcee40a908327a641e7fb3d6dc125)