### PR TITLE
Move SkyBound gear section below learning content

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 9:33PM EST
+———————————————————————
+Change: Moved the SkyBound gear section below the learning and Part 107 guidance to guide visitors through the content flow.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open skybound.html → confirm Learn & Watch, Shops, and Part 107 sections appear before Gear.
+2. Open skybound.html → click Gear filters and confirm the cards update.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-21 | 9:17PM EST
 ———————————————————————
 Change: Added SkyBound to the Tools dropdown across the site and inserted the standard nav on skybound.html.

--- a/skybound.html
+++ b/skybound.html
@@ -638,23 +638,6 @@
         <p>Drone gear, FPV resources, and your path to Part 107 certification.</p>
     </section>
 
-    <!-- Gear Section -->
-    <div class="container">
-        <h2 class="section-title">Gear</h2>
-        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
-
-        <div class="filter-tabs">
-            <button class="filter-tab active" data-filter="all">All</button>
-            <button class="filter-tab" data-filter="goggles">Goggles</button>
-            <button class="filter-tab" data-filter="radio">Radios</button>
-            <button class="filter-tab" data-filter="drone">Drones</button>
-        </div>
-
-        <div class="grid grid-3" id="products-grid">
-            <!-- Products will be inserted here by JavaScript -->
-        </div>
-    </div>
-
     <!-- Resources Section -->
     <div class="container">
         <h2 class="section-title">Learn & Watch</h2>
@@ -721,6 +704,23 @@
 
         <div class="resource-list" id="official-links">
             <!-- Official links will be inserted here by JavaScript -->
+        </div>
+    </div>
+
+    <!-- Gear Section -->
+    <div class="container">
+        <h2 class="section-title">Gear</h2>
+        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
+
+        <div class="filter-tabs">
+            <button class="filter-tab active" data-filter="all">All</button>
+            <button class="filter-tab" data-filter="goggles">Goggles</button>
+            <button class="filter-tab" data-filter="radio">Radios</button>
+            <button class="filter-tab" data-filter="drone">Drones</button>
+        </div>
+
+        <div class="grid grid-3" id="products-grid">
+            <!-- Products will be inserted here by JavaScript -->
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Guide visitors through learning and certification content first, then present gear recommendations so users explore, learn, and watch before shopping.

### Description
- Reordered the HTML in `skybound.html` to place the `Learn & Watch`, `Shops`, and `Part 107 Path` sections before the `Gear` section.
- Left product rendering and filter JavaScript unchanged so the existing filter buttons and cards continue to function.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the reorder and providing a manual verification checklist.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697145d60c308327ba2a9e456cf3d958)