### PR TITLE
Remove LaB Pick badge from Bardwell QAV-S 2 and update changelog

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,26 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 9:35PM EST
+———————————————————————
+Change: Removed the LaB Pick badge from the Bardwell QAV-S 2 gear card.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open skybound.html → scroll to Gear and confirm the Bardwell QAV-S 2 card has no LaB Pick badge.
+2. Open skybound.html → click gear filters and confirm cards still update.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
+2026-01-21 | 9:33PM EST
+———————————————————————
+Change: Moved the SkyBound gear section below the learning and Part 107 guidance to guide visitors through the content flow.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open skybound.html → confirm Learn & Watch, Shops, and Part 107 sections appear before Gear.
+2. Open skybound.html → click Gear filters and confirm the cards update.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-21 | 9:17PM EST
 ———————————————————————
 Change: Added SkyBound to the Tools dropdown across the site and inserted the standard nav on skybound.html.

--- a/skybound.html
+++ b/skybound.html
@@ -638,23 +638,6 @@
         <p>Drone gear, FPV resources, and your path to Part 107 certification.</p>
     </section>
 
-    <!-- Gear Section -->
-    <div class="container">
-        <h2 class="section-title">Gear</h2>
-        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
-
-        <div class="filter-tabs">
-            <button class="filter-tab active" data-filter="all">All</button>
-            <button class="filter-tab" data-filter="goggles">Goggles</button>
-            <button class="filter-tab" data-filter="radio">Radios</button>
-            <button class="filter-tab" data-filter="drone">Drones</button>
-        </div>
-
-        <div class="grid grid-3" id="products-grid">
-            <!-- Products will be inserted here by JavaScript -->
-        </div>
-    </div>
-
     <!-- Resources Section -->
     <div class="container">
         <h2 class="section-title">Learn & Watch</h2>
@@ -724,6 +707,23 @@
         </div>
     </div>
 
+    <!-- Gear Section -->
+    <div class="container">
+        <h2 class="section-title">Gear</h2>
+        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
+
+        <div class="filter-tabs">
+            <button class="filter-tab active" data-filter="all">All</button>
+            <button class="filter-tab" data-filter="goggles">Goggles</button>
+            <button class="filter-tab" data-filter="radio">Radios</button>
+            <button class="filter-tab" data-filter="drone">Drones</button>
+        </div>
+
+        <div class="grid grid-3" id="products-grid">
+            <!-- Products will be inserted here by JavaScript -->
+        </div>
+    </div>
+
     <script>
         // Data from constants
         const PRODUCTS = [
@@ -735,7 +735,7 @@
             { id: 'femto', name: 'BetaFPV Pavo Femto', description: 'Ultra-light brushless whoop. Note: Requires DJI O4 Air Unit for digital FPV.', link: 'https://betafpv.com/collections/betafpv-naked-camera-series/products/pavo-femto-brushless-whoop-quadcopter', category: 'drone', badge: 'Micro King' },
             { id: 'pavo20pro', name: 'BetaFPV Pavo 20 Pro', description: 'Cinewhoop for DJI O4 Air Unit. Pro-grade performance in a compact frame.', link: 'https://betafpv.com/collections/betafpv-naked-camera-series/products/pavo20-pro-brushless-whoop-quadcopter?variant=42022567477382', category: 'drone' },
             { id: 'pavo20pro2', name: 'BetaFPV Pavo 20 Pro II', description: 'Next-gen Pavo 20. Note: Requires DJI O4 Pro Unit for maximum imaging quality.', link: 'https://betafpv.com/collections/betafpv-naked-camera-series/products/pavo20-pro-ii-brushless-whoop-quadcopter', category: 'drone' },
-            { id: 'qavs2', name: 'QAV-S 2 Sub-250 Bardwell SE', description: 'The definitive 3" DIY kit by Joshua Bardwell. Sub-250g weight. (Does not include O4 Pro Unit).', link: 'https://www.getfpv.com/beginner-diy-fpv-drone-kit-qav-s-2-sub-250-joshua-bardwell-se-3-hd-ready.html', category: 'drone', badge: 'LaB Pick - Power' }
+            { id: 'qavs2', name: 'QAV-S 2 Sub-250 Bardwell SE', description: 'The definitive 3" DIY kit by Joshua Bardwell. Sub-250g weight. (Does not include O4 Pro Unit).', link: 'https://www.getfpv.com/beginner-diy-fpv-drone-kit-qav-s-2-sub-250-joshua-bardwell-se-3-hd-ready.html', category: 'drone' }
         ];
 
         const CHANNELS = [


### PR DESCRIPTION
### Motivation
- Remove the "LaB Pick" badge from the Bardwell QAV‑S 2 gear card to correct curated labeling and record the change.

### Description
- Removed the `badge` attribute from the `qavs2` entry in the `PRODUCTS` array inside `skybound.html` so the card no longer renders the LaB Pick label.
- Added a new entry to `CHANGELOG_RUNNING.md` documenting the badge removal and included a manual verification checklist.

### Testing
- Automated tests were not run in CI (environment restriction); manual verification steps are listed in `CHANGELOG_RUNNING.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697145d60c308327ba2a9e456cf3d958)