### PR TITLE
Refresh SkyBound layout: intro flow, simulators, logo, and gear defaults

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 9:50PM EST
+———————————————————————
+Change: Overhauled SkyBound layout with new intro flow, simulators section, updated hero copy, and reordered sections.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: Updated the SkyBound nav logo and removed the LaB Pick badge from Joshua Bardwell.
+Quick test checklist:
+1. Open skybound.html → confirm intro, simulators, Learn & Watch, Gear, Shops, Part 107, and Official FAA Links appear in that order.
+2. Open skybound.html → click Gear filters and confirm the radios filter is active by default and updates the grid.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-21 | 9:33PM EST
 ———————————————————————
 Change: Moved the SkyBound gear section below the learning and Part 107 guidance to guide visitors through the content flow.

--- a/skybound.html
+++ b/skybound.html
@@ -205,6 +205,21 @@
             margin-bottom: 1rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            justify-content: center;
+            gap: 1rem;
+        }
+
+        .hero .hero-tagline {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            color: var(--light-gray);
+            border: 1px solid var(--gray);
+            padding: 0.35rem 0.75rem;
         }
 
         .hero p {
@@ -248,6 +263,10 @@
 
         .grid-2 {
             grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+        }
+
+        .grid-4 {
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
         }
 
         /* Cards */
@@ -308,6 +327,14 @@
 
         .card-link:hover::after {
             margin-left: 1rem;
+        }
+
+        .card-meta {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--light-gray);
         }
 
         /* Filter Tabs */
@@ -554,6 +581,11 @@
                 padding: 6rem 1.5rem 3rem;
             }
 
+            .hero h1 {
+                flex-direction: column;
+                gap: 0.5rem;
+            }
+
             .container {
                 padding: 3rem 1.5rem;
             }
@@ -592,7 +624,7 @@
     <!-- Navigation -->
     <nav class="site-nav">
         <a href="index.html">
-            <img src="images/LaBMedia.png" alt="LaB Media" class="nav-logo">
+            <img src="images/WhiteBeakerLogo.png" alt="LaB Media" class="nav-logo">
         </a>
         <button class="menu-toggle" id="menuToggle" aria-label="Toggle menu" aria-expanded="false">
             <span></span>
@@ -634,9 +666,55 @@
 
     <!-- Hero -->
     <section class="hero">
-        <h1>SkyBound</h1>
+        <h1>
+            SkyBound
+            <span class="hero-tagline">a resource by LaB Media</span>
+        </h1>
         <p>Drone gear, FPV resources, and your path to Part 107 certification.</p>
     </section>
+
+    <!-- Explanation Section -->
+    <div class="container">
+        <h2 class="section-title">Start Here</h2>
+        <p class="section-subtitle">SkyBound is a guided path: learn the basics, simulate before you buy, then build your kit and certification plan.</p>
+
+        <div class="grid grid-4">
+            <div class="card">
+                <div class="card-badge">01</div>
+                <h3>Simulators</h3>
+                <p>Fly safely, build muscle memory, and save money before you invest in hardware.</p>
+                <div class="card-meta">Confidence → Control</div>
+            </div>
+            <div class="card">
+                <div class="card-badge">02</div>
+                <h3>Learn & Watch</h3>
+                <p>Follow trusted pilots and training channels that explain the why, not just the how.</p>
+                <div class="card-meta">Knowledge → Skill</div>
+            </div>
+            <div class="card">
+                <div class="card-badge">03</div>
+                <h3>Gear & Shops</h3>
+                <p>Start with radios, then goggles and drones. Buy from reputable vendors.</p>
+                <div class="card-meta">Setup → Flight</div>
+            </div>
+            <div class="card">
+                <div class="card-badge">04</div>
+                <h3>Part 107</h3>
+                <p>Go legit with the FAA path and official resources to fly commercially.</p>
+                <div class="card-meta">Practice → Certification</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Simulators Section -->
+    <div class="container">
+        <h2 class="section-title">Simulators</h2>
+        <p class="section-subtitle">Train your reflexes before buying hardware. Sim time makes every first flight safer.</p>
+
+        <div class="resource-list" id="simulators-list">
+            <!-- Simulators will be inserted here by JavaScript -->
+        </div>
+    </div>
 
     <!-- Resources Section -->
     <div class="container">
@@ -645,6 +723,23 @@
 
         <div class="resource-list" id="channels-list">
             <!-- Channels will be inserted here by JavaScript -->
+        </div>
+    </div>
+
+    <!-- Gear Section -->
+    <div class="container">
+        <h2 class="section-title">Gear</h2>
+        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
+
+        <div class="filter-tabs">
+            <button class="filter-tab active" data-filter="radio">Radios</button>
+            <button class="filter-tab" data-filter="goggles">Goggles</button>
+            <button class="filter-tab" data-filter="drone">Drones</button>
+            <button class="filter-tab" data-filter="all">All</button>
+        </div>
+
+        <div class="grid grid-3" id="products-grid">
+            <!-- Products will be inserted here by JavaScript -->
         </div>
     </div>
 
@@ -698,29 +793,15 @@
                 </div>
             </div>
         </div>
+    </div>
 
-        <h3 class="section-title" style="margin-top: 3rem; font-size: 2rem;">Official FAA Links</h3>
+    <!-- Official Links Section -->
+    <div class="container">
+        <h2 class="section-title">Official FAA Links</h2>
         <p class="section-subtitle">Government resources for certification</p>
 
         <div class="resource-list" id="official-links">
             <!-- Official links will be inserted here by JavaScript -->
-        </div>
-    </div>
-
-    <!-- Gear Section -->
-    <div class="container">
-        <h2 class="section-title">Gear</h2>
-        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
-
-        <div class="filter-tabs">
-            <button class="filter-tab active" data-filter="all">All</button>
-            <button class="filter-tab" data-filter="goggles">Goggles</button>
-            <button class="filter-tab" data-filter="radio">Radios</button>
-            <button class="filter-tab" data-filter="drone">Drones</button>
-        </div>
-
-        <div class="grid grid-3" id="products-grid">
-            <!-- Products will be inserted here by JavaScript -->
         </div>
     </div>
 
@@ -739,7 +820,7 @@
         ];
 
         const CHANNELS = [
-            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell', isLaBPick: true },
+            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell' },
             { name: 'DJI', description: 'Official channel for the industry-leading camera drone ecosystem.', url: 'https://www.dji.com/camera-drones' },
             { name: 'BetaFPV', description: 'Masters of the micro drone. Great for compact systems and learning builds.', url: 'https://betafpv.com' },
             { name: 'CAPTAIN DRONE', description: 'Comprehensive FPV tutorials, reviews, and high-quality flight content.', url: 'https://www.youtube.com/@CAPTAINDRONE798' },
@@ -747,6 +828,13 @@
             { name: 'BOTGRINDER', description: 'Aggressive freestyle, raw energy, and pure FPV inspiration.', url: 'https://www.youtube.com/@BOTGRINDER' },
             { name: 'Mike Sytes (Part 107)', description: 'Walkthroughs and practical guidance for the Part 107 exam.', url: 'https://www.youtube.com/@mikesytes' },
             { name: 'Mr. Migs Classroom', description: 'Structured classroom-style lessons covering everything in the Part 107.', url: 'https://www.youtube.com/@MrMigsClassroom' }
+        ];
+
+        const SIMULATORS = [
+            { name: 'Liftoff', description: 'The most popular FPV sim for freestyle and muscle memory training.', url: 'https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/' },
+            { name: 'VelociDrone', description: 'Racing-focused sim with deep tuning and multiplayer options.', url: 'https://www.velocidrone.com' },
+            { name: 'DRL Simulator', description: 'Beginner-friendly, with structured training modes and real-world tracks.', url: 'https://store.steampowered.com/app/641780/The_DRL_Simulator/' },
+            { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' }
         ];
 
         const SHOPS = [
@@ -803,8 +891,9 @@
         });
 
         // Initial render
-        renderProducts();
+        renderProducts('radio');
         renderResourceList(CHANNELS, 'channels-list');
+        renderResourceList(SIMULATORS, 'simulators-list');
         renderResourceList(SHOPS, 'shops-list');
         renderResourceList(OFFICIAL_LINKS, 'official-links');
 


### PR DESCRIPTION
### Motivation
- Improve the SkyBound page flow so visitors progress from explanation → simulators → learning → gear → shops → Part 107 → official links.
- Correct branding and hero copy by using the intended white logo and adding a tasteful tagline next to the `SkyBound` title.  
- Remove an internal "LaB Pick" badge from Joshua Bardwell to avoid incorrect attribution and simplify the resource list.

### Description
- Reworked `skybound.html` layout to add a new "Start Here" overview grid, a dedicated `Simulators` section, and reordered sections to match the requested progression.  
- Added `SIMULATORS` data and render target (`simulators-list`), introduced `.grid-4` and `.card-meta` styles, and adjusted hero markup/CSS to include the tagline.  
- Swapped the nav logo to `images/WhiteBeakerLogo.png`, removed the `isLaBPick` flag from the Joshua Bardwell channel entry, and adjusted the gear filter order so `Radios` is first.  
- Made the gear view default to radios by calling `renderProducts('radio')` on load and updated the running changelog in `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).  
- Manual verification checklist: Open `skybound.html` and confirm the visible section order is: Start Here, Simulators, Learn & Watch, Gear, Shops, Part 107 Path, Official FAA Links.  
- Manual verification checklist: Confirm the top-left nav image is `WhiteBeakerLogo.png` and the hero shows the tagline `a resource by LaB Media` next to the `SkyBound` title.  
- Manual verification checklist: Click Gear filter tabs and confirm `Radios` is active by default and the product grid updates when switching filters; open DevTools console and confirm no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697149e991f08327b47a37ccb42e97f3)