### PR TITLE
Restore SkyBound list rendering and add guarded JS population

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,65 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 10:45PM EST
+———————————————————————
+Change: Restored SkyBound simulators and Watch/Learn list rendering with a fallback that preserves existing HTML.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open skybound.html → confirm Simulators and Watch & Learn sections render items.
+2. Refresh skybound.html → confirm the lists remain visible after reload.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
+2026-01-21 | 10:18PM EST
+———————————————————————
+Change: Hardcoded SkyBound simulators and Watch/Learn channel lists to ensure they render reliably.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open skybound.html → confirm Simulators shows Liftoff, VelociDrone, and Uncrashed.
+2. Open skybound.html → confirm Watch & Learn lists Joshua Bardwell, Watch channels, and Learn channels.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
+2026-01-21 | 10:03PM EST
+———————————————————————
+Change: Reordered SkyBound content so Gear appears before Watch & Learn and split Watch & Learn into Watch/Learn lists.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: Removed DJI and BetaFPV from channels since they are shops, not channels.
+Quick test checklist:
+1. Open skybound.html → confirm Gear appears before Watch & Learn.
+2. Open skybound.html → confirm Watch & Learn shows Joshua Bardwell, Watch list, and Learn list in that order.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
+2026-01-21 | 10:03PM EST
+———————————————————————
+Change: Moved Gear above Watch & Learn and split Watch & Learn into dedicated Watch and Learn sections with updated channels.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: Removed DJI/BetaFPV from channels since they are shops, not channels.
+Quick test checklist:
+1. Open skybound.html → confirm Gear now appears before Watch & Learn.
+2. Open skybound.html → confirm Watch & Learn shows Joshua Bardwell, Watch list, and Learn list in that order.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
+2026-01-21 | 10:00PM EST
+———————————————————————
+Change: Removed the DRL Simulator listing from the SkyBound simulators section.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+Quick test checklist:
+1. Open skybound.html → confirm the Simulators list no longer includes DRL Simulator.
+2. Open DevTools Console on skybound.html and confirm no errors.
+
+2026-01-21 | 9:50PM EST
+———————————————————————
+Change: Overhauled SkyBound layout with new intro flow, simulators section, updated hero copy, and reordered sections.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: Updated the SkyBound nav logo and removed the LaB Pick badge from Joshua Bardwell.
+Quick test checklist:
+1. Open skybound.html → confirm intro, simulators, Learn & Watch, Gear, Shops, Part 107, and Official FAA Links appear in that order.
+2. Open skybound.html → click Gear filters and confirm the radios filter is active by default and updates the grid.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-21 | 9:33PM EST
 ———————————————————————
 Change: Moved the SkyBound gear section below the learning and Part 107 guidance to guide visitors through the content flow.

--- a/skybound.html
+++ b/skybound.html
@@ -205,6 +205,21 @@
             margin-bottom: 1rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            justify-content: center;
+            gap: 1rem;
+        }
+
+        .hero .hero-tagline {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            color: var(--light-gray);
+            border: 1px solid var(--gray);
+            padding: 0.35rem 0.75rem;
         }
 
         .hero p {
@@ -248,6 +263,10 @@
 
         .grid-2 {
             grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+        }
+
+        .grid-4 {
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
         }
 
         /* Cards */
@@ -308,6 +327,14 @@
 
         .card-link:hover::after {
             margin-left: 1rem;
+        }
+
+        .card-meta {
+            font-family: 'Space Mono', monospace;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--light-gray);
         }
 
         /* Filter Tabs */
@@ -554,6 +581,11 @@
                 padding: 6rem 1.5rem 3rem;
             }
 
+            .hero h1 {
+                flex-direction: column;
+                gap: 0.5rem;
+            }
+
             .container {
                 padding: 3rem 1.5rem;
             }
@@ -592,7 +624,7 @@
     <!-- Navigation -->
     <nav class="site-nav">
         <a href="index.html">
-            <img src="images/LaBMedia.png" alt="LaB Media" class="nav-logo">
+            <img src="images/WhiteBeakerLogo.png" alt="LaB Media" class="nav-logo">
         </a>
         <button class="menu-toggle" id="menuToggle" aria-label="Toggle menu" aria-expanded="false">
             <span></span>
@@ -634,17 +666,151 @@
 
     <!-- Hero -->
     <section class="hero">
-        <h1>SkyBound</h1>
+        <h1>
+            SkyBound
+            <span class="hero-tagline">a resource by LaB Media</span>
+        </h1>
         <p>Drone gear, FPV resources, and your path to Part 107 certification.</p>
     </section>
 
-    <!-- Resources Section -->
+    <!-- Explanation Section -->
     <div class="container">
-        <h2 class="section-title">Learn & Watch</h2>
-        <p class="section-subtitle">YouTube channels and resources worth following</p>
+        <h2 class="section-title">Start Here</h2>
+        <p class="section-subtitle">SkyBound is a guided path: learn the basics, simulate before you buy, then build your kit and certification plan.</p>
 
-        <div class="resource-list" id="channels-list">
-            <!-- Channels will be inserted here by JavaScript -->
+        <div class="grid grid-4">
+            <div class="card">
+                <div class="card-badge">01</div>
+                <h3>Simulators</h3>
+                <p>Fly safely, build muscle memory, and save money before you invest in hardware.</p>
+                <div class="card-meta">Confidence → Control</div>
+            </div>
+            <div class="card">
+                <div class="card-badge">02</div>
+                <h3>Learn & Watch</h3>
+                <p>Follow trusted pilots and training channels that explain the why, not just the how.</p>
+                <div class="card-meta">Knowledge → Skill</div>
+            </div>
+            <div class="card">
+                <div class="card-badge">03</div>
+                <h3>Gear & Shops</h3>
+                <p>Start with radios, then goggles and drones. Buy from reputable vendors.</p>
+                <div class="card-meta">Setup → Flight</div>
+            </div>
+            <div class="card">
+                <div class="card-badge">04</div>
+                <h3>Part 107</h3>
+                <p>Go legit with the FAA path and official resources to fly commercially.</p>
+                <div class="card-meta">Practice → Certification</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Simulators Section -->
+    <div class="container">
+        <h2 class="section-title">Simulators</h2>
+        <p class="section-subtitle">Train your reflexes before buying hardware. Sim time makes every first flight safer.</p>
+
+        <div class="resource-list" id="simulators-list">
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>Liftoff</h4>
+                    <p>The most popular FPV sim for freestyle and muscle memory training.</p>
+                </div>
+                <a href="https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>VelociDrone</h4>
+                    <p>Racing-focused sim with deep tuning and multiplayer options.</p>
+                </div>
+                <a href="https://www.velocidrone.com" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>Uncrashed</h4>
+                    <p>Freestyle-heavy sim with fast load times and smooth feel.</p>
+                </div>
+                <a href="https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Gear Section -->
+    <div class="container">
+        <h2 class="section-title">Gear</h2>
+        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
+
+        <div class="filter-tabs">
+            <button class="filter-tab active" data-filter="radio">Radios</button>
+            <button class="filter-tab" data-filter="goggles">Goggles</button>
+            <button class="filter-tab" data-filter="drone">Drones</button>
+            <button class="filter-tab" data-filter="all">All</button>
+        </div>
+
+        <div class="grid grid-3" id="products-grid">
+            <!-- Products will be inserted here by JavaScript -->
+        </div>
+    </div>
+
+    <!-- Watch & Learn Section -->
+    <div class="container">
+        <h2 class="section-title">Watch & Learn</h2>
+        <p class="section-subtitle">Learn from the best, then dive into focused watch and study tracks.</p>
+
+        <div class="resource-list" id="featured-channel">
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>Joshua Bardwell</h4>
+                    <p>The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.</p>
+                </div>
+                <a href="https://www.youtube.com/@JoshuaBardwell" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+        </div>
+
+        <h3 class="section-title" style="margin-top: 3rem; font-size: 2rem;">Watch</h3>
+        <p class="section-subtitle">Freestyle, reviews, and inspiration to sharpen your eye.</p>
+        <div class="resource-list" id="watch-list">
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>CAPTAIN DRONE</h4>
+                    <p>Comprehensive FPV tutorials, reviews, and high-quality flight content.</p>
+                </div>
+                <a href="https://www.youtube.com/@CAPTAINDRONE798" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>Mr Steele</h4>
+                    <p>Legendary FPV freestyle. The gold standard for cinematic movement.</p>
+                </div>
+                <a href="https://www.youtube.com/@MrSteeleFPV" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>BOTGRINDER</h4>
+                    <p>Aggressive freestyle, raw energy, and pure FPV inspiration.</p>
+                </div>
+                <a href="https://www.youtube.com/@BOTGRINDER" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+        </div>
+
+        <h3 class="section-title" style="margin-top: 3rem; font-size: 2rem;">Learn</h3>
+        <p class="section-subtitle">Study-first channels to prep for knowledge tests and airspace rules.</p>
+        <div class="resource-list" id="learn-list">
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>Mike Sytes (Part 107)</h4>
+                    <p>Walkthroughs and practical guidance for the Part 107 exam.</p>
+                </div>
+                <a href="https://www.youtube.com/@mikesytes" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
+            <div class="resource-item">
+                <div class="resource-info">
+                    <h4>Mr. Migs Classroom</h4>
+                    <p>Structured classroom-style lessons covering everything in the Part 107.</p>
+                </div>
+                <a href="https://www.youtube.com/@MrMigsClassroom" target="_blank" class="resource-link-btn">Visit</a>
+            </div>
         </div>
     </div>
 
@@ -698,29 +864,15 @@
                 </div>
             </div>
         </div>
+    </div>
 
-        <h3 class="section-title" style="margin-top: 3rem; font-size: 2rem;">Official FAA Links</h3>
+    <!-- Official Links Section -->
+    <div class="container">
+        <h2 class="section-title">Official FAA Links</h2>
         <p class="section-subtitle">Government resources for certification</p>
 
         <div class="resource-list" id="official-links">
             <!-- Official links will be inserted here by JavaScript -->
-        </div>
-    </div>
-
-    <!-- Gear Section -->
-    <div class="container">
-        <h2 class="section-title">Gear</h2>
-        <p class="section-subtitle">Curated equipment for FPV and drone work</p>
-
-        <div class="filter-tabs">
-            <button class="filter-tab active" data-filter="all">All</button>
-            <button class="filter-tab" data-filter="goggles">Goggles</button>
-            <button class="filter-tab" data-filter="radio">Radios</button>
-            <button class="filter-tab" data-filter="drone">Drones</button>
-        </div>
-
-        <div class="grid grid-3" id="products-grid">
-            <!-- Products will be inserted here by JavaScript -->
         </div>
     </div>
 
@@ -736,17 +888,6 @@
             { id: 'pavo20pro', name: 'BetaFPV Pavo 20 Pro', description: 'Cinewhoop for DJI O4 Air Unit. Pro-grade performance in a compact frame.', link: 'https://betafpv.com/collections/betafpv-naked-camera-series/products/pavo20-pro-brushless-whoop-quadcopter?variant=42022567477382', category: 'drone' },
             { id: 'pavo20pro2', name: 'BetaFPV Pavo 20 Pro II', description: 'Next-gen Pavo 20. Note: Requires DJI O4 Pro Unit for maximum imaging quality.', link: 'https://betafpv.com/collections/betafpv-naked-camera-series/products/pavo20-pro-ii-brushless-whoop-quadcopter', category: 'drone' },
             { id: 'qavs2', name: 'QAV-S 2 Sub-250 Bardwell SE', description: 'The definitive 3" DIY kit by Joshua Bardwell. Sub-250g weight. (Does not include O4 Pro Unit).', link: 'https://www.getfpv.com/beginner-diy-fpv-drone-kit-qav-s-2-sub-250-joshua-bardwell-se-3-hd-ready.html', category: 'drone' }
-        ];
-
-        const CHANNELS = [
-            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell', isLaBPick: true },
-            { name: 'DJI', description: 'Official channel for the industry-leading camera drone ecosystem.', url: 'https://www.dji.com/camera-drones' },
-            { name: 'BetaFPV', description: 'Masters of the micro drone. Great for compact systems and learning builds.', url: 'https://betafpv.com' },
-            { name: 'CAPTAIN DRONE', description: 'Comprehensive FPV tutorials, reviews, and high-quality flight content.', url: 'https://www.youtube.com/@CAPTAINDRONE798' },
-            { name: 'Mr Steele', description: 'Legendary FPV freestyle. The gold standard for cinematic movement.', url: 'https://www.youtube.com/@MrSteeleFPV' },
-            { name: 'BOTGRINDER', description: 'Aggressive freestyle, raw energy, and pure FPV inspiration.', url: 'https://www.youtube.com/@BOTGRINDER' },
-            { name: 'Mike Sytes (Part 107)', description: 'Walkthroughs and practical guidance for the Part 107 exam.', url: 'https://www.youtube.com/@mikesytes' },
-            { name: 'Mr. Migs Classroom', description: 'Structured classroom-style lessons covering everything in the Part 107.', url: 'https://www.youtube.com/@MrMigsClassroom' }
         ];
 
         const SHOPS = [
@@ -782,6 +923,15 @@
 
         function renderResourceList(items, containerId) {
             const container = document.getElementById(containerId);
+            if (!container) {
+                return;
+            }
+
+            const existingItems = container.querySelectorAll('.resource-item');
+            if (existingItems.length) {
+                return;
+            }
+
             container.innerHTML = items.map(item => `
                 <div class="resource-item ${item.isLaBPick ? 'lab-pick' : ''}">
                     <div class="resource-info">
@@ -802,9 +952,33 @@
             });
         });
 
+        const FEATURED_CHANNEL = [
+            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell' }
+        ];
+
+        const WATCH_CHANNELS = [
+            { name: 'CAPTAIN DRONE', description: 'Comprehensive FPV tutorials, reviews, and high-quality flight content.', url: 'https://www.youtube.com/@CAPTAINDRONE798' },
+            { name: 'Mr Steele', description: 'Legendary FPV freestyle. The gold standard for cinematic movement.', url: 'https://www.youtube.com/@MrSteeleFPV' },
+            { name: 'BOTGRINDER', description: 'Aggressive freestyle, raw energy, and pure FPV inspiration.', url: 'https://www.youtube.com/@BOTGRINDER' }
+        ];
+
+        const LEARN_CHANNELS = [
+            { name: 'Mike Sytes (Part 107)', description: 'Walkthroughs and practical guidance for the Part 107 exam.', url: 'https://www.youtube.com/@mikesytes' },
+            { name: 'Mr. Migs Classroom', description: 'Structured classroom-style lessons covering everything in the Part 107.', url: 'https://www.youtube.com/@MrMigsClassroom' }
+        ];
+
+        const SIMULATORS = [
+            { name: 'Liftoff', description: 'The most popular FPV sim for freestyle and muscle memory training.', url: 'https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/' },
+            { name: 'VelociDrone', description: 'Racing-focused sim with deep tuning and multiplayer options.', url: 'https://www.velocidrone.com' },
+            { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' }
+        ];
+
         // Initial render
-        renderProducts();
-        renderResourceList(CHANNELS, 'channels-list');
+        renderProducts('radio');
+        renderResourceList(FEATURED_CHANNEL, 'featured-channel');
+        renderResourceList(WATCH_CHANNELS, 'watch-list');
+        renderResourceList(LEARN_CHANNELS, 'learn-list');
+        renderResourceList(SIMULATORS, 'simulators-list');
         renderResourceList(SHOPS, 'shops-list');
         renderResourceList(OFFICIAL_LINKS, 'official-links');
 


### PR DESCRIPTION
### Motivation
- Fix empty Simulators and Watch & Learn sections that appeared when JavaScript attempted to populate lists at render time and overwrote or failed to populate content. 
- Ensure key learning and simulator resources remain visible on initial load and after reloads even if JS data is missing or runs later. 
- Preserve any existing server-/author-authored HTML entries while allowing JS-driven population when the lists are empty. 
- Record the change in the running changelog for operational visibility.

### Description
- Added guard logic to `renderResourceList` so it returns if the target container is missing or already contains `.resource-item` entries, preventing accidental overwrites of hardcoded HTML. 
- Reintroduced JS data arrays `FEATURED_CHANNEL`, `WATCH_CHANNELS`, `LEARN_CHANNELS`, and `SIMULATORS` and wired them into the initial render calls so JS will populate lists when the HTML is empty. 
- Populated `skybound.html` with hardcoded entries for Simulators and Watch/Learn sections and adjusted initial product render to call `renderProducts('radio')`; also retained shop and official links rendering via `SHOPS` and `OFFICIAL_LINKS`. 
- Minor layout/content tweaks: added a hero tagline, `grid-4` start-here cards, `card-meta` styling, and updated `CHANGELOG_RUNNING.md` with a verification checklist.

### Testing
- Automated tests: none were run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697149e991f08327b47a37ccb42e97f3)