### PR TITLE
Fix SkyBound resource rendering

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 11:14PM EST
+———————————————————————
+Change: Restored SkyBound resource lists by wiring featured/watch/learn and simulator data to the current sections.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: Reinstated missing resources from the prior version and re-enabled the LaB Pick badge on the featured channel.
+Quick test checklist:
+1. Open skybound.html → confirm Featured, Watch, and Learn lists populate with channels.
+2. Open skybound.html → confirm Simulators list shows Liftoff, VelociDrone, DRL Simulator, and Uncrashed.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-21 | 9:50PM EST
 ———————————————————————
 Change: Overhauled SkyBound layout with new intro flow, simulators section, updated hero copy, and reordered sections.

--- a/skybound.html
+++ b/skybound.html
@@ -831,27 +831,6 @@
             { id: 'qavs2', name: 'QAV-S 2 Sub-250 Bardwell SE', description: 'The definitive 3" DIY kit by Joshua Bardwell. Sub-250g weight. (Does not include O4 Pro Unit).', link: 'https://www.getfpv.com/beginner-diy-fpv-drone-kit-qav-s-2-sub-250-joshua-bardwell-se-3-hd-ready.html', category: 'drone' }
         ];
 
-        const CHANNELS = [
-            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell' },
-            { name: 'DJI', description: 'Official channel for the industry-leading camera drone ecosystem.', url: 'https://www.dji.com/camera-drones' },
-            { name: 'BetaFPV', description: 'Masters of the micro drone. Great for compact systems and learning builds.', url: 'https://betafpv.com' },
-            { name: 'CAPTAIN DRONE', description: 'Comprehensive FPV tutorials, reviews, and high-quality flight content.', url: 'https://www.youtube.com/@CAPTAINDRONE798' },
-            { name: 'Mr Steele', description: 'Legendary FPV freestyle. The gold standard for cinematic movement.', url: 'https://www.youtube.com/@MrSteeleFPV' },
-            { name: 'BOTGRINDER', description: 'Aggressive freestyle, raw energy, and pure FPV inspiration.', url: 'https://www.youtube.com/@BOTGRINDER' }
-        ];
-
-        const LEARN_CHANNELS = [
-            { name: 'Mike Sytes (Part 107)', description: 'Walkthroughs and practical guidance for the Part 107 exam.', url: 'https://www.youtube.com/@mikesytes' },
-            { name: 'Mr. Migs Classroom', description: 'Structured classroom-style lessons covering everything in the Part 107.', url: 'https://www.youtube.com/@MrMigsClassroom' }
-        ];
-
-        const SIMULATORS = [
-            { name: 'Liftoff', description: 'The most popular FPV sim for freestyle and muscle memory training.', url: 'https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/' },
-            { name: 'VelociDrone', description: 'Racing-focused sim with deep tuning and multiplayer options.', url: 'https://www.velocidrone.com' },
-            { name: 'DRL Simulator', description: 'Beginner-friendly, with structured training modes and real-world tracks.', url: 'https://store.steampowered.com/app/641780/The_DRL_Simulator/' },
-            { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' }
-        ];
-
         const SHOPS = [
             { name: 'GetFPV', description: 'Major US retailer for all things FPV.', url: 'https://www.getfpv.com' },
             { name: 'RaceDayQuads', description: 'Fast shipping and a massive inventory.', url: 'https://www.racedayquads.com' },
@@ -915,10 +894,12 @@
         });
 
         const FEATURED_CHANNEL = [
-            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell' }
+            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell', isLaBPick: true }
         ];
 
         const WATCH_CHANNELS = [
+            { name: 'DJI', description: 'Official channel for the industry-leading camera drone ecosystem.', url: 'https://www.dji.com/camera-drones' },
+            { name: 'BetaFPV', description: 'Masters of the micro drone. Great for compact systems and learning builds.', url: 'https://betafpv.com' },
             { name: 'CAPTAIN DRONE', description: 'Comprehensive FPV tutorials, reviews, and high-quality flight content.', url: 'https://www.youtube.com/@CAPTAINDRONE798' },
             { name: 'Mr Steele', description: 'Legendary FPV freestyle. The gold standard for cinematic movement.', url: 'https://www.youtube.com/@MrSteeleFPV' },
             { name: 'BOTGRINDER', description: 'Aggressive freestyle, raw energy, and pure FPV inspiration.', url: 'https://www.youtube.com/@BOTGRINDER' }
@@ -932,12 +913,15 @@
         const SIMULATORS = [
             { name: 'Liftoff', description: 'The most popular FPV sim for freestyle and muscle memory training.', url: 'https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/' },
             { name: 'VelociDrone', description: 'Racing-focused sim with deep tuning and multiplayer options.', url: 'https://www.velocidrone.com' },
+            { name: 'DRL Simulator', description: 'Beginner-friendly, with structured training modes and real-world tracks.', url: 'https://store.steampowered.com/app/641780/The_DRL_Simulator/' },
             { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' }
         ];
 
         // Initial render
         renderProducts('radio');
-        renderResourceList(CHANNELS, 'channels-list');
+        renderResourceList(FEATURED_CHANNEL, 'featured-channel');
+        renderResourceList(WATCH_CHANNELS, 'watch-list');
+        renderResourceList(LEARN_CHANNELS, 'learn-list');
         renderResourceList(SIMULATORS, 'simulators-list');
         renderResourceList(SHOPS, 'shops-list');
         renderResourceList(OFFICIAL_LINKS, 'official-links');


### PR DESCRIPTION
### Motivation
- Restore missing resource lists on the SkyBound page so featured/watch/learn channels and simulators render again for visitors.
- Re-enable the LaB Pick badge on the featured channel and keep page behavior consistent with the prior working version.

### Description
- Wired the featured/watch/learn arrays into the page by adding `FEATURED_CHANNEL`, `WATCH_CHANNELS`, and `LEARN_CHANNELS` and restored `SIMULATORS` items so the corresponding DOM sections are populated.
- Updated the initial render calls to `renderResourceList` for `featured-channel`, `watch-list`, `learn-list`, `simulators-list`, `shops-list`, and `official-links` and kept the guard that prevents double-insert.
- Marked the featured channel with `isLaBPick: true` so the `LaB Pick` badge appears again.
- Added a changelog entry in `CHANGELOG_RUNNING.md` documenting the fix.

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification: Open `skybound.html` and confirm the Featured, Watch, and Learn lists populate with channels in their sections.
- Manual verification: Open `skybound.html` and confirm the Simulators list shows Liftoff, VelociDrone, DRL Simulator, and Uncrashed.
- Manual verification: Click the Gear filter tabs on `skybound.html` and confirm the products grid updates and the `Radios` filter is active by default.
- Manual verification: Open DevTools Console on `skybound.html` and confirm there are no JavaScript errors and no CSP/connect issues.
- Manual verification: Confirm `CHANGELOG_RUNNING.md` has a new top entry describing this change and lists `skybound.html` and `CHANGELOG_RUNNING.md` under Files touched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69715db6b29c8327a09f6ceceeafd736)