### PR TITLE
Remove DRL Simulator and LaB Pick tag from SkyBound

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 11:55PM EST
+———————————————————————
+Change: Removed the DRL Simulator entry and cleared the LaB Pick tag from the Joshua Bardwell channel on SkyBound.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: Header nav links already matched the site-standard dropdown structure.
+Quick test checklist:
+1. Open skybound.html → confirm the Simulators list excludes DRL Simulator.
+2. Open skybound.html → confirm Joshua Bardwell no longer shows a LaB Pick tag.
+3. Open skybound.html → click Community and Tools dropdowns in the header nav to confirm links open.
+4. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-21 | 11:14PM EST
 ———————————————————————
 Change: Restored SkyBound resource lists by wiring featured/watch/learn and simulator data to the current sections.

--- a/skybound.html
+++ b/skybound.html
@@ -894,7 +894,7 @@
         });
 
         const FEATURED_CHANNEL = [
-            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell', isLaBPick: true }
+            { name: 'Joshua Bardwell', description: 'The "Godfather" of FPV. Deep dives into gear, building, and troubleshooting.', url: 'https://www.youtube.com/@JoshuaBardwell' }
         ];
 
         const WATCH_CHANNELS = [
@@ -913,7 +913,6 @@
         const SIMULATORS = [
             { name: 'Liftoff', description: 'The most popular FPV sim for freestyle and muscle memory training.', url: 'https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/' },
             { name: 'VelociDrone', description: 'Racing-focused sim with deep tuning and multiplayer options.', url: 'https://www.velocidrone.com' },
-            { name: 'DRL Simulator', description: 'Beginner-friendly, with structured training modes and real-world tracks.', url: 'https://store.steampowered.com/app/641780/The_DRL_Simulator/' },
             { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' }
         ];
 


### PR DESCRIPTION
### Motivation
- Remove the DRL Simulator entry and clear the LaB Pick tag to reflect updated content decisions on the SkyBound resources page and keep the featured channel badges accurate.

### Description
- Deleted the `DRL Simulator` object from the `SIMULATORS` array in `skybound.html` so the simulators list no longer includes that entry.
- Removed the `isLaBPick: true` flag from the Joshua Bardwell entry in the `FEATURED_CHANNEL` array in `skybound.html` so it no longer renders the LaB Pick badge.
- Appended a new entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification checklist: Open `skybound.html` and confirm the Simulators list excludes `DRL Simulator`.
- Manual verification checklist: Open `skybound.html` and confirm Joshua Bardwell no longer shows a LaB Pick tag.
- Manual verification checklist: Interact with the header nav dropdowns (Community and Tools) on `skybound.html` to confirm links open.
- Manual verification checklist: Open DevTools Console on `skybound.html` and confirm there are no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971660c3d1883278d68fe651e2fa763)