### PR TITLE
Add Isaac Haines to music resources

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 9:29PM EST
+———————————————————————
+Change: Added Isaac Haines music resource entry with Gumroad, SoundCloud, and Instagram links.
+Files touched: resources-data.js, CHANGELOG_RUNNING.md
+Notes: None.
+Quick test checklist:
+1. Open resources.html → filter to Tools > Resources > Music and confirm Isaac Haines appears with Gumroad link.
+2. Open Isaac Haines modal → confirm SoundCloud and Instagram links open correctly.
+3. Open DevTools Console on resources.html and confirm no errors.
+
 2026-01-21 | 11:55PM EST
 ———————————————————————
 Change: Removed the DRL Simulator entry and cleared the LaB Pick tag from the Joshua Bardwell channel on SkyBound.

--- a/resources-data.js
+++ b/resources-data.js
@@ -1285,6 +1285,25 @@ const resources = [
     },
 
     {
+        name: 'Isaac Haines',
+        category: 'music',
+        desc: 'Composer sharing tracks and downloads via Gumroad.',
+        fullDesc: 'Isaac Haines offers music downloads through Gumroad, with additional releases and listening options on SoundCloud and Instagram.',
+        url: 'https://isaachaines.gumroad.com/l/vxmswi',
+        instagramUrl: 'https://www.instagram.com/lsaachaines/?hl=en',
+        additionalLinks: [
+            {
+                label: 'SoundCloud',
+                url: 'https://soundcloud.com/isaachaines',
+                type: 'website',
+                description: 'Stream Isaac Haines tracks on SoundCloud.'
+            }
+        ],
+        paid: true,
+        features: ['Composer', 'Digital Downloads', 'SoundCloud Streams']
+    },
+
+    {
         name: 'ProductionCrate Music',
         category: 'music',
         desc: 'Free and premium music library tied to ProductionCrate assets.',


### PR DESCRIPTION
### Motivation
- Add Isaac Haines to the Tools > Resources > Music list so visitors can find his Gumroad downloads and listening links (SoundCloud, Instagram).

### Description
- Added an `Isaac Haines` resource object to `resources-data.js` with `url: https://isaachaines.gumroad.com/l/vxmswi`, `instagramUrl`, a SoundCloud entry in `additionalLinks`, `paid: true`, and feature tags, and appended an entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69718b58cb7c8327ad4dd42cd50a7357)