### PR TITLE
Add Zane Hoyer editing reference and update changelog

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,26 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-21 | 9:35PM EST
+———————————————————————
+Change: Added Zane Hoyer editing reference entry with YouTube channel and featured video.
+Files touched: resources-data.js, CHANGELOG_RUNNING.md
+Notes: None.
+Quick test checklist:
+1. Open resources.html → filter to References > Editing and confirm Zane Hoyer appears.
+2. Open Zane Hoyer modal → confirm the YouTube link opens and the featured video embeds.
+3. Open DevTools Console on resources.html and confirm no errors.
+
+2026-01-21 | 9:29PM EST
+———————————————————————
+Change: Added Isaac Haines music resource entry with Gumroad, SoundCloud, and Instagram links.
+Files touched: resources-data.js, CHANGELOG_RUNNING.md
+Notes: None.
+Quick test checklist:
+1. Open resources.html → filter to Tools > Resources > Music and confirm Isaac Haines appears with Gumroad link.
+2. Open Isaac Haines modal → confirm SoundCloud and Instagram links open correctly.
+3. Open DevTools Console on resources.html and confirm no errors.
+
 2026-01-21 | 11:55PM EST
 ———————————————————————
 Change: Removed the DRL Simulator entry and cleared the LaB Pick tag from the Joshua Bardwell channel on SkyBound.

--- a/resources-data.js
+++ b/resources-data.js
@@ -973,6 +973,18 @@ const resources = [
     },
 
     {
+        name: 'Zane Hoyer',
+        category: 'references',
+        refType: 'editing',
+        desc: 'Editor-focused YouTube channel covering pacing, structure, and storytelling.',
+        fullDesc: 'Zane Hoyer shares editing insights for narrative and creator-led projects, with breakdowns on pacing, story structure, and decision-making in the cut.',
+        url: 'https://www.youtube.com/@zanehoyer',
+        paid: false,
+        featuredVideo: 'zDhau3u5NbY',
+        features: ['Editing', 'Pacing', 'Story Structure', 'YouTube Craft']
+    },
+
+    {
         name: 'Gawx Art',
         category: 'references',
         refType: 'art',
@@ -1282,6 +1294,25 @@ const resources = [
         url: 'https://ende.app',
         paid: false,
         features: ['Cinematic Focus', 'Clear Usage Notes', 'Ambient & Trailer Ready', 'Attribution Guidance']
+    },
+
+    {
+        name: 'Isaac Haines',
+        category: 'music',
+        desc: 'Composer sharing tracks and downloads via Gumroad.',
+        fullDesc: 'Isaac Haines offers music downloads through Gumroad, with additional releases and listening options on SoundCloud and Instagram.',
+        url: 'https://isaachaines.gumroad.com/l/vxmswi',
+        instagramUrl: 'https://www.instagram.com/lsaachaines/?hl=en',
+        additionalLinks: [
+            {
+                label: 'SoundCloud',
+                url: 'https://soundcloud.com/isaachaines',
+                type: 'website',
+                description: 'Stream Isaac Haines tracks on SoundCloud.'
+            }
+        ],
+        paid: true,
+        features: ['Composer', 'Digital Downloads', 'SoundCloud Streams']
     },
 
     {


### PR DESCRIPTION
### Motivation
- Add Zane Hoyer as a References > Editing resource so the channel and example video can appear in the modal popup and be discoverable from the site.
- Record the change in the running changelog for traceability and manual verification steps.

### Description
- Inserted a new resource object for Zane Hoyer into `resources-data.js` with `name`, `category: 'references'`, `refType: 'editing'`, `url: 'https://www.youtube.com/@zanehoyer'`, `featuredVideo: 'zDhau3u5NbY'`, and relevant description and feature tags.
- Added a top entry to `CHANGELOG_RUNNING.md` documenting the addition and a quick manual verification checklist.
- Positioned the new entry near other editing references so it appears when filtering to References > Editing.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69718b58cb7c8327ad4dd42cd50a7357)