### PR TITLE
Add Tryp FPV and FPV Logic simulator resources

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-23 | 4:01AM EST
+———————————————————————
+Change: Added Tryp FPV and FPV Logic to FPV simulator resources and SkyBound simulator list.
+Files touched: resources-data.js, skybound.html, CHANGELOG_RUNNING.md
+Notes: None.
+Quick test checklist:
+1. Open resources.html → filter to Drone resources and confirm Tryp FPV + FPV Logic appear under software/simulators.
+2. Open skybound.html → scroll to Simulators list and confirm both entries appear with working links.
+3. Open DevTools Console on resources.html and skybound.html and confirm no errors.
+
 2026-01-21 | 9:29PM EST
 ———————————————————————
 Change: Added Isaac Haines music resource entry with Gumroad, SoundCloud, and Instagram links.

--- a/resources-data.js
+++ b/resources-data.js
@@ -654,6 +654,28 @@ const resources = [
         features: ['FPV Simulator', 'Realistic Physics', 'Multiplayer Racing', 'Practice Tool']
     },
 
+    {
+        name: 'Tryp FPV',
+        category: 'drone',
+        droneType: 'software',
+        desc: 'Freestyle-focused FPV simulator with cinematic environments.',
+        fullDesc: 'Tryp FPV emphasizes smooth freestyle flying with handcrafted environments and a focus on flow. A solid option for building muscle memory and exploring cinematic lines before risking real gear.',
+        url: 'https://trypfpv.com',
+        paid: true,
+        features: ['FPV Simulator', 'Freestyle Practice', 'Cinematic Maps', 'Muscle Memory']
+    },
+
+    {
+        name: 'FPV Logic',
+        category: 'drone',
+        droneType: 'software',
+        desc: 'FPV simulator built around practice and tuneable flight feel.',
+        fullDesc: 'FPV Logic offers an approachable FPV sim experience with multiple tracks and settings to adjust feel as you train. Great for practice sessions that sharpen throttle control, timing, and line choice.',
+        url: 'https://fpvlogic.com',
+        paid: true,
+        features: ['FPV Simulator', 'Adjustable Feel', 'Practice Tracks', 'Training Tool']
+    },
+
 
     // ============================================
     // AI TOOLS

--- a/skybound.html
+++ b/skybound.html
@@ -912,8 +912,10 @@
 
         const SIMULATORS = [
             { name: 'Liftoff', description: 'The most popular FPV sim for freestyle and muscle memory training.', url: 'https://store.steampowered.com/app/410340/Liftoff_FPV_Drone_Racing/' },
+            { name: 'Tryp FPV', description: 'Freestyle-first sim with cinematic environments and flow-focused flying.', url: 'https://trypfpv.com' },
             { name: 'VelociDrone', description: 'Racing-focused sim with deep tuning and multiplayer options.', url: 'https://www.velocidrone.com' },
-            { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' }
+            { name: 'Uncrashed', description: 'Freestyle-heavy sim with fast load times and smooth feel.', url: 'https://store.steampowered.com/app/1682970/Uncrashed__FPV_Drone_Simulator/' },
+            { name: 'FPV Logic', description: 'Adjustable sim for practice sessions, throttle control, and line choice.', url: 'https://fpvlogic.com' }
         ];
 
         // Initial render


### PR DESCRIPTION
### Motivation
- Expand FPV simulation options in the Drone resources to help pilots practice freestyle and tune flight feel before flying real hardware.
- Surface these simulators on the SkyBound guidance page so visitors can quickly find simulator recommendations alongside other FPV tools.

### Description
- Added `Tryp FPV` and `FPV Logic` entries to the drone software/simulator resources in `resources-data.js`.
- Added `Tryp FPV` and `FPV Logic` to the `SIMULATORS` array in `skybound.html` so they render on the SkyBound page.
- Appended a new entry documenting the change to `CHANGELOG_RUNNING.md` with a manual verification checklist.
- Files touched: `resources-data.js`, `skybound.html`, `CHANGELOG_RUNNING.md`.

### Testing
- Automated tests: Not run (environment restriction).
- Manual verification checklist: Open `resources.html` and filter to Drone resources to confirm `Tryp FPV` and `FPV Logic` appear under software/simulators.
- Manual verification checklist: Open `skybound.html` and scroll to the Simulators list to confirm both entries appear and their links open in a new tab/window.
- Manual verification checklist: Open DevTools Console on `resources.html` and `skybound.html` and confirm there are no JavaScript console errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f202ad3c8327bfe0a8b6d0d043e2)