### PR TITLE
Remove BetaFPV from SkyBound watch list

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-23 | 4:24AM EST
+———————————————————————
+Change: Removed BetaFPV from the SkyBound watch list since it is already listed in shops.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes: None.
+Quick test checklist:
+1. Open skybound.html → confirm BetaFPV no longer appears in the Watch list.
+2. Open skybound.html → confirm BetaFPV still appears in the Shops list.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-23 | 4:01AM EST
 ———————————————————————
 Change: Added Tryp FPV and FPV Logic to FPV simulator resources and SkyBound simulator list.

--- a/skybound.html
+++ b/skybound.html
@@ -899,7 +899,6 @@
 
         const WATCH_CHANNELS = [
             { name: 'DJI', description: 'Official channel for the industry-leading camera drone ecosystem.', url: 'https://www.dji.com/camera-drones' },
-            { name: 'BetaFPV', description: 'Masters of the micro drone. Great for compact systems and learning builds.', url: 'https://betafpv.com' },
             { name: 'CAPTAIN DRONE', description: 'Comprehensive FPV tutorials, reviews, and high-quality flight content.', url: 'https://www.youtube.com/@CAPTAINDRONE798' },
             { name: 'Mr Steele', description: 'Legendary FPV freestyle. The gold standard for cinematic movement.', url: 'https://www.youtube.com/@MrSteeleFPV' },
             { name: 'BOTGRINDER', description: 'Aggressive freestyle, raw energy, and pure FPV inspiration.', url: 'https://www.youtube.com/@BOTGRINDER' }


### PR DESCRIPTION
### Motivation
- Remove a duplicate listing: BetaFPV appeared in both the Shops and Watch lists on SkyBound, so it should be removed from the Watch list to avoid redundancy.

### Description
- Deleted the BetaFPV entry from the `WATCH_CHANNELS` array in `skybound.html` and added a changelog entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction); manual verification: open `skybound.html` and confirm BetaFPV no longer appears in the Watch list, confirm BetaFPV still appears under Shops, and check the DevTools console on `skybound.html` for no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f7d5038c83278c2d659266a1df6e)