### PR TITLE
Add Detroit Independent Film Festival to resources

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-24 | 10:12AM EST
+———————————————————————
+Change: Added Detroit Independent Film Festival to the resources film festivals list.
+Files touched: resources-data.js, CHANGELOG_RUNNING.md
+Notes: Added FilmFreeway link and Detroit location metadata.
+Quick test checklist:
+1. Open resources.html → filter to Film Festivals and confirm Detroit Independent Film Festival appears.
+2. Open the Detroit Independent Film Festival modal → confirm the FilmFreeway link works.
+3. Open DevTools Console on resources.html and confirm no errors.
+
 2026-01-23 | 4:24AM EST
 ———————————————————————
 Change: Removed BetaFPV from the SkyBound watch list since it is already listed in shops.

--- a/resources-data.js
+++ b/resources-data.js
@@ -266,6 +266,20 @@ const resources = [
     },
 
     {
+        id: 'detroit-independent-film-festival',
+        name: 'Detroit Independent Film Festival',
+        category: 'film-festivals',
+        desc: 'Detroit festival celebrating independent film with screenings and filmmaker visibility.',
+        fullDesc: 'Detroit Independent Film Festival spotlights independent films with a Detroit backdrop, offering local and visiting filmmakers a platform for screenings, recognition, and community visibility.',
+        filmFreewayUrl: 'https://filmfreeway.com/DetroitIndependentFilmFestival',
+        paid: true,
+        keyInfo: [
+            { label: 'Location', value: 'Detroit, MI' }
+        ],
+        features: ['Detroit-Based', 'Independent Film', 'Screenings', 'FilmFreeway Submissions']
+    },
+
+    {
         name: 'Cinetopia Film Festival',
         category: 'film-festivals',
         desc: 'Ann Arbor festival showcasing independent cinema.',


### PR DESCRIPTION
### Motivation
- Add the Detroit Independent Film Festival to the film festivals resources so local filmmakers can discover the festival and access its FilmFreeway submission link.

### Description
- Inserted a new `film-festivals` entry (`id: 'detroit-independent-film-festival'`) in `resources-data.js` with `filmFreewayUrl`, `Location: Detroit, MI` metadata, and feature tags, and appended a corresponding entry to `CHANGELOG_RUNNING.md` documenting the change.

### Testing
- Automated tests: Not run (environment restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974035e8c7c8327b5ed1ada5612f696)