### PR TITLE
Homepage: tighten Start here onboarding

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-25 | 4:46PM EST
+———————————————————————
+Change: Tightened homepage “Start here” module for faster onboarding.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes:
+1. Reduced visual weight/padding so the section reads as a quick control panel.
+2. Shortened copy to be more scannable.
+Quick test checklist:
+1. Open index.html → confirm Start here appears under hero and reads cleanly.
+2. Confirm the three actions are obvious and still route to events/resources/ideas.
+3. Open DevTools Console on index.html and confirm no errors.
+
 2026-01-25 | 4:05PM EST
 ———————————————————————
 Change: SkyBound layout compacted with collapsible sections; removed blue accents.

--- a/index.html
+++ b/index.html
@@ -631,7 +631,7 @@
            START HERE (HOMEPAGE QUICK ACTIONS)
         ============================================ */
         .start-here {
-            padding: 3rem clamp(1.5rem, 4vw, 3.5rem) 1rem;
+            padding: 2.25rem clamp(1.5rem, 4vw, 3.5rem) 1rem;
             position: relative;
             z-index: 2;
         }
@@ -673,12 +673,11 @@
         .start-card {
             display: flex;
             flex-direction: column;
-            gap: 0.75rem;
-            padding: 1.25rem 1.25rem 1.1rem;
+            gap: 0.65rem;
+            padding: 1.1rem 1.15rem 1.05rem;
             border-radius: 18px;
             text-decoration: none;
             color: var(--white);
-            min-height: 140px;
         }
 
         .start-card-kicker {
@@ -2267,7 +2266,7 @@
             <div class="start-here-head">
                 <div>
                     <div class="section-label proto-text-mono">Start here</div>
-                    <div class="start-here-desc">This is the hub. Three quick jumps to get you moving.</div>
+                    <div class="start-here-desc">Three quick jumps. No scrolling required.</div>
                 </div>
                 <div class="section-count proto-text-mono">03</div>
             </div>
@@ -2280,7 +2279,7 @@
                     <span class="proto-corner-br"></span>
                     <div class="start-card-kicker">Community</div>
                     <div class="start-card-name">Find events</div>
-                    <div class="start-card-copy">Metro Detroit calendar. Dates change—links included so you can verify fast.</div>
+                    <div class="start-card-copy">Metro Detroit calendar with direct source links.</div>
                     <div class="start-card-cta">Open calendar <span aria-hidden="true">→</span></div>
                 </a>
 
@@ -2291,7 +2290,7 @@
                     <span class="proto-corner-br"></span>
                     <div class="start-card-kicker">Toolkit</div>
                     <div class="start-card-name">Find resources</div>
-                    <div class="start-card-copy">Browse + filter. Save the stuff you actually use and come back later.</div>
+                    <div class="start-card-copy">Browse + filter the tools. Save what you’ll reuse.</div>
                     <div class="start-card-cta">Browse resources <span aria-hidden="true">→</span></div>
                 </a>
 
@@ -2302,7 +2301,7 @@
                     <span class="proto-corner-br"></span>
                     <div class="start-card-kicker">Core tool</div>
                     <div class="start-card-name">Get unstuck</div>
-                    <div class="start-card-copy">Roll a constraint and build something shootable. Momentum over scripts.</div>
+                    <div class="start-card-copy">Roll a constraint and build something shootable.</div>
                     <div class="start-card-cta">Generate an idea <span aria-hidden="true">→</span></div>
                 </a>
             </div>


### PR DESCRIPTION
Phase 1 / PR1\n\nTightens the homepage ‘Start here’ module to read as a quick onboarding control panel:\n- Slightly reduced padding/visual weight\n- Shorter, more scannable copy\n\nIncludes CHANGELOG_RUNNING.md update.