### PR TITLE
Resources: add Collections presets

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,18 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-25 | 5:00PM EST
+———————————————————————
+Change: Resources “Collections” (curated bundles as preset filters).
+Files touched: resources.html, CHANGELOG_RUNNING.md
+Notes:
+1. Adds a Collections row with curated presets (Starter Short Kit / Festival Stack / Local Network).
+2. Implemented as preset filter states (no backend / no schema changes).
+Quick test checklist:
+1. Open resources.html → click each Collection button → confirm it jumps to the intended category/filters.
+2. Click Clear → returns to default view.
+3. Open DevTools Console and confirm no errors.
+
 2026-01-25 | 4:49PM EST
 ———————————————————————
 Change: Callboard urgency badges (New / Closing soon / X days left).

--- a/resources.html
+++ b/resources.html
@@ -3009,6 +3009,14 @@
             </div>
         </div>
 
+        <!-- Collections Row (curated bundles) -->
+        <div class="quickfilter-row" id="collectionBar" aria-label="Collections">
+            <button class="quickfilter-btn" type="button" data-collection="starter-short">Starter Short Kit</button>
+            <button class="quickfilter-btn" type="button" data-collection="festival-stack">Festival Stack</button>
+            <button class="quickfilter-btn" type="button" data-collection="local-network">Local Network</button>
+            <button class="quickfilter-btn" type="button" data-collection="reset">Clear</button>
+        </div>
+
         <!-- Quick Filters Row -->
         <div class="quickfilter-row" id="quickFilterBar" aria-label="Quick filters">
             <button class="quickfilter-btn" type="button" id="suggestQuick" title="Help keep this useful — suggest one link">
@@ -3172,6 +3180,9 @@
         const droneTypeBar = document.getElementById('droneTypeBar');
         const droneTypeButtons = droneTypeBar ? droneTypeBar.querySelectorAll('.subfilter-btn') : [];
 
+        const collectionBar = document.getElementById('collectionBar');
+        const collectionButtons = collectionBar ? collectionBar.querySelectorAll('.quickfilter-btn') : [];
+
         const quickFilterBar = document.getElementById('quickFilterBar');
         const quickFilterButtons = quickFilterBar ? quickFilterBar.querySelectorAll('.quickfilter-btn') : [];
         const suggestQuickBtn = document.getElementById('suggestQuick');
@@ -3196,6 +3207,24 @@
         const savedClose = document.getElementById('savedClose');
         const savedBackdrop = document.getElementById('savedBackdrop');
 
+        // Collections (curated bundles)
+        // Implemented as preset filter states (no backend / no schema changes).
+        const COLLECTIONS = {
+            'starter-short': {
+                label: 'Starter Short Kit',
+                group: 'tools',
+                toolsSubcategory: 'gear'
+            },
+            'festival-stack': {
+                label: 'Festival Stack',
+                group: 'film-festivals'
+            },
+            'local-network': {
+                label: 'Local Network',
+                group: 'community',
+                communitySubcategory: 'all'
+            }
+        };
         // Current filter state
         let currentGroup = 'film-festivals';
         let communitySubcategory = 'all';
@@ -4587,6 +4616,44 @@
                 renderResources(true);
             });
         });
+
+        // Collections (preset filter states)
+        if (collectionButtons.length) {
+            collectionButtons.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const key = btn.dataset.collection;
+                    if (!key) return;
+
+                    // Clear quick filters
+                    Object.keys(quickFilters).forEach(k => quickFilters[k] = false);
+                    quickFilterButtons.forEach(b => b.classList.remove('is-active'));
+                    currentSort = 'alpha';
+
+                    if (key === 'reset') {
+                        setGroup('film-festivals');
+                        showToast('Cleared collection');
+                        renderResources(true);
+                        return;
+                    }
+
+                    const preset = COLLECTIONS[key];
+                    if (!preset) return;
+
+                    setGroup(preset.group);
+                    if (preset.group === 'tools' && preset.toolsSubcategory) {
+                        toolsSubcategory = preset.toolsSubcategory;
+                        toolsGroupButtons.forEach(b => b.classList.toggle('active', b.dataset.tools === toolsSubcategory));
+                    }
+                    if (preset.group === 'community' && preset.communitySubcategory) {
+                        communitySubcategory = preset.communitySubcategory;
+                        communityGroupButtons.forEach(b => b.classList.toggle('active', b.dataset.community === communitySubcategory));
+                    }
+
+                    showToast(preset.label);
+                    renderResources(true);
+                });
+            });
+        }
 
         // Quick filters (multi-toggle)
         if (quickFilterButtons.length) {


### PR DESCRIPTION
Phase 2 / PR6\n\nAdds a ‘Collections’ row (curated bundles) implemented as preset filter states (no backend):\n- Starter Short Kit\n- Festival Stack\n- Local Network\n- Clear\n\nIncludes CHANGELOG_RUNNING.md update.