### PR TITLE
SkyBound: default all sections collapsed

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,17 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-25 | 5:08PM EST
+———————————————————————
+Change: SkyBound default state = all collapsible sections closed.
+Files touched: skybound.html, CHANGELOG_RUNNING.md
+Notes:
+1. Removes default `open` state from Step 1/3/5 so SkyBound loads fully collapsed.
+Quick test checklist:
+1. Open skybound.html in a private window → confirm all sections are collapsed.
+2. Expand/collapse a few sections → confirm content renders inside each.
+3. Open DevTools Console on skybound.html and confirm no errors.
+
 2026-01-25 | 5:00PM EST
 ———————————————————————
 Change: Resources “Collections” (curated bundles as preset filters).

--- a/skybound.html
+++ b/skybound.html
@@ -778,7 +778,7 @@
 
     <!-- Simulators Section -->
     <div class="container">
-        <details class="section" open>
+        <details class="section">
             <summary class="section-summary">
                 <div class="summary-left">
                     <div class="summary-kicker">Step 1</div>
@@ -824,7 +824,7 @@
             </div>
         </details>
 
-        <details class="section" open>
+        <details class="section">
             <summary class="section-summary">
                 <div class="summary-left">
                     <div class="summary-kicker">Step 3</div>
@@ -865,7 +865,7 @@
             </div>
         </details>
 
-        <details class="section" open>
+        <details class="section">
             <summary class="section-summary">
                 <div class="summary-left">
                     <div class="summary-kicker">Step 5</div>


### PR DESCRIPTION
Fixes SkyBound default state: removes the  attribute so all collapsible sections start closed on first load.\n\nIncludes CHANGELOG_RUNNING.md update.