### PR TITLE
Homepage: fix GSAP target-not-found warnings

### DIFF
--- a/CHANGELOG_RUNNING.md
+++ b/CHANGELOG_RUNNING.md
@@ -4,6 +4,16 @@ Purpose: compressed memory of shipped changes. Keep it short. Add newest at top.
 
 **IMPORTANT:** This changelog MUST be updated with every code change, no matter how small. Before committing or deploying, add an entry documenting what was changed, which files were touched, and how to verify the change works.
 
+2026-01-25 | 5:11PM EST
+———————————————————————
+Change: Homepage GSAP warning cleanup for event preview cards.
+Files touched: index.html, CHANGELOG_RUNNING.md
+Notes:
+1. Guards the GSAP animation so it only runs when .event-preview-card elements exist.
+Quick test checklist:
+1. Open index.html → scroll to Events preview → confirm animations still occur.
+2. Check DevTools Console → confirm GSAP “target not found” warnings are gone.
+
 2026-01-25 | 5:00PM EST
 ———————————————————————
 Change: Resources “Collections” (curated bundles as preset filters).

--- a/index.html
+++ b/index.html
@@ -3201,18 +3201,21 @@
             ease: 'power3.out'
         });
 
-        gsap.from('.event-preview-card', {
-            scrollTrigger: {
-                trigger: '.events-preview-grid',
-                start: 'top 75%'
-            },
-            opacity: 0,
-            x: -40,
-            duration: 0.7,
-            stagger: 0.12,
-            ease: 'power2.out',
-            delay: 0.3
-        });
+        // Guard: cards are injected dynamically; only animate if they exist.
+        if (document.querySelector('.event-preview-card')) {
+            gsap.from('.event-preview-card', {
+                scrollTrigger: {
+                    trigger: '.events-preview-grid',
+                    start: 'top 75%'
+                },
+                opacity: 0,
+                x: -40,
+                duration: 0.7,
+                stagger: 0.12,
+                ease: 'power2.out',
+                delay: 0.3
+            });
+        }
 
         gsap.from('.events-preview .view-all', {
             scrollTrigger: {


### PR DESCRIPTION
Guards GSAP animation for dynamically injected .event-preview-card elements to prevent console warnings when cards aren’t present yet.\n\nIncludes CHANGELOG_RUNNING.md update.